### PR TITLE
compose/modules/README(es/en) ok; typos corrigidos em compose/all-in-…

### DIFF
--- a/compose/all-in-one/README_en.md
+++ b/compose/all-in-one/README_en.md
@@ -73,7 +73,7 @@ Stop the service with the following command.
 sudo docker-compose stop SERVICE_NAME
 ```
 
-Start the service again with the following command
+Start the service again with the following command.
 
 ```bash
 sudo docker-compose start SERVICE_NAME

--- a/compose/all-in-one/README_es.md
+++ b/compose/all-in-one/README_es.md
@@ -48,8 +48,8 @@ Verificar el estatus de los contenedores con el siguiente comando.
 ```bash
 sudo docker-compose ps
 ```
-Se mostrará una lista de servicios con el estatus correspondiente.
 
+Se mostrará una lista de servicios con el estatus correspondiente.
 
 ## Solución de problemas
 

--- a/compose/modules/README.md
+++ b/compose/modules/README.md
@@ -20,8 +20,7 @@ Neste método, cada módulo pode ser instanciado separadamente.
 
 ## Requisitos
 
-Acesse [essa página](../README.md), na seção ``Requisitos``, para obter informações sobre como instalar 
-as dependências para o funcionamento dos módulos.
+Acesse [essa página](../README.md), na seção **Requisitos**, para obter informações sobre como instalar as dependências para o funcionamento dos módulos.
 
 # Deploy
 
@@ -29,8 +28,7 @@ as dependências para o funcionamento dos módulos.
 
 ### Logstash
 
-* Edite o arquivo ``logstash-federated/logstash.env`` e altere os valores definidos como 
-**CHANGE_HERE** para os valores condizentes com seu ambiente.
+* Edite o arquivo ``logstash-federated/logstash.env`` e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente.
 
 * Edite o arquivo ``logstash-federated/logstash-federated.yaml`` e altere a versão do módulo, conforme as instruções [dessa página](../README.md), na seção **Alterando a Versão dos Módulos, Porta e Outros Parâmetros**.
 
@@ -42,13 +40,11 @@ sudo docker-compose -f logstash-federated/logstash-federated.yaml up -d
 
 ### Agent-Authorization
 
-* Edite o arquivo ``agent-authorization/agent-authorization.env`` e altere os valores definidos como 
-**CHANGE_HERE** para os valores condizentes com seu ambiente.
+* Edite o arquivo ``agent-authorization/agent-authorization.env`` e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente.
 
 * Crie um token de acesso do ambiente híbrido no API-Manager seguindo as instruções [dessa página](../README.md), na seção **Criação de Token**.
 
 * Edite o arquivo ``agent-authorization/agent-authorization.yaml`` e altere a versão do módulo, conforme as instruções [dessa página](../README.md), na seção **Alterando a Versão dos Módulos, Porta e Outros Parâmetros**.
-
 
 * Execute o serviço usando o ``docker-compose`` com o seguinte comando.
 
@@ -58,8 +54,7 @@ sudo docker-compose -f agent-authorization.yaml up -d
 
 ### Agent-Gateway
 
-* Edite o arquivo ``agent-gateway/agent-gateway.env`` e altere os valores definidos como 
-**CHANGE_HERE** para os valores condizentes com seu ambiente.
+* Edite o arquivo ``agent-gateway/agent-gateway.env`` e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente.
 
 * Crie um token de acesso do ambiente híbrido no API-Manager seguindo as instruções [dessa página](../README.md), na seção **Criação de Token**.
 
@@ -73,8 +68,7 @@ sudo docker-compose -d -f agent-gateway/agent-gateway.yaml up
 
 ### API-Authorization
 
-* Edite o arquivo ``api-authorization/api-authorization.env`` e altere os valores definidos como 
-**CHANGE_HERE** para os valores condizentes com seu ambiente.
+* Edite o arquivo ``api-authorization/api-authorization.env`` e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente.
 
 * Edite o arquivo ``api-authorization/api-authorization.yaml`` e altere a versão do módulo, conforme as instruções [dessa página](../README.md), na seção **Alterando a Versão dos Módulos, Porta e Outros Parâmetros**.
 
@@ -86,8 +80,7 @@ sudo docker-compose -f api-authorization/api-authorization.yaml up -d
 
 ### API-Gateway
 
-* Edite o arquivo ``api-gateway/api-gateway.env`` e altere os valores definidos como 
-**CHANGE_HERE** para os valores condizentes com seu ambiente.
+* Edite o arquivo ``api-gateway/api-gateway.env`` e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente.
 
 * Edite o arquivo ``api-gateway/api-gateway.yaml`` e altere a versão do módulo, conforme as instruções [dessa página](../README.md), na seção **Alterando a Versão dos Módulos, Porta e Outros Parâmetros**.
 
@@ -122,7 +115,7 @@ sudo docker-compose logs -f SERVICE_NAME
 
 Altere o termo ``NOME_DIR`` pelo diretório do serviço.
 
-O termo ``SERVICE_NAME`` deve ser substituído pelo nome do serviço que você deseja visualizar o log.
+O termo ``SERVICE_NAME`` deve ser substituído pelo nome do serviço cujo log você deseja visualizar.
 
 Reinicie o serviço com os seguintes comandos.
 
@@ -145,8 +138,7 @@ cd NOME_DIR
 sudo docker-compose start SERVICE_NAME
 ```
 
-Se quiser parar o serviço e remover todos os dados, volumes, imagens, rede dos contêineres 
-use os comandos a seguir (use apenas se realmente precisar).
+Se quiser parar o serviço e remover todos os dados, volumes, imagens, rede dos contêineres, use os comandos a seguir (use apenas se realmente precisar).
 
 ```bash
 cd NOME_DIR

--- a/compose/modules/README_en.md
+++ b/compose/modules/README_en.md
@@ -1,0 +1,146 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# Hybrid API-Platform - Docker Compose Modules
+
+In this method, each module can be instanced separately.
+
+## Requirements
+
+Access the **Requirements** section of [this page](../README.md) to read on how to install the dependencies for the modules to run.
+
+# Deploy
+
+## Installation
+
+### Logstash
+
+* Edit the file ``logstash-federated/logstash.env`` and replace the values defines as **CHANGE_HERE** with values consistent with your environment.
+
+* Edit the file ``logstash-federated/logstash-federated.yaml`` and change the module version, according to the instructions on the **Changing Modules Version, Port and Other Parameters** section of [this page](../README.md).
+
+* Execute the service using ``docker-compose`` with the following command.
+
+```bash
+sudo docker-compose -f logstash-federated/logstash-federated.yaml up -d
+```
+
+### Agent-Authorization
+
+* Edit the file ``agent-authorization/agent-authorization.env`` and replace the values defines as **CHANGE_HERE** with values consistent with your environment.
+
+* Create an access token for the hybrid environment on API-Manager following the instruction on the **Token Generation** section of [this page](../README.md).
+
+* Edit the file ``agent-authorization/agent-authorization.yaml`` and change the module version, according to the instructions on the **Changing Modules Version, Port and Other Parameters** section of [this page](../README.md).
+
+* Execute the service using ``docker-compose`` with the following command.
+
+```bash
+sudo docker-compose -f agent-authorization.yaml up -d
+```
+
+### Agent-Gateway
+
+* Edit the file ``agent-gateway/agent-gateway.env`` and replace the values defines as **CHANGE_HERE** with values consistent with your environment.
+
+* Create an access token for the hybrid environment on API-Manager following the instruction on the **Token Generation** section of [this page](../README.md).
+
+* Edit the file ``agent-gateway/agent-gateway.yaml`` and change the module version, according to the instructions on the **Changing Modules Version, Port and Other Parameters** section of [this page](../README.md).
+
+* Execute the service using ``docker-compose`` with the following command.
+
+```bash
+sudo docker-compose -d -f agent-gateway/agent-gateway.yaml up
+```
+
+### API-Authorization
+
+* Edit the file ``api-authorization/api-authorization.env`` and replace the values defines as **CHANGE_HERE** with values consistent with your environment.
+
+* Edit the file ``api-authorization/api-authorization.yaml`` and change the module version, according to the instructions on the **Changing Modules Version, Port and Other Parameters** section of [this page](../README.md).
+
+* Execute the service using ``docker-compose`` with the following command.
+
+```bash
+sudo docker-compose -f api-authorization/api-authorization.yaml up -d
+```
+
+### API-Gateway
+
+* Edit the file ``api-gateway/api-gateway.env`` and replace the values defines as **CHANGE_HERE** with values consistent with your environment.
+
+* Edit the file ``api-gateway/api-gateway.yaml`` and change the module version, according to the instructions on the **Changing Modules Version, Port and Other Parameters** section of [this page](../README.md).
+
+* Execute the service using ``docker-compose`` with the following command.
+
+```bash
+sudo docker-compose -f api-gateway/api-gateway.yaml up -d
+```
+
+## Validation
+
+See container status with the following command.
+
+```bash
+sudo docker-compose -f DIR_NAME/COMPOSE_FILE_NAME ps
+```
+
+Replace the term ``DIR_NAME`` with the service directory.
+
+Replace the term ``COMPOSE_FILE_NAME`` with the service file.
+
+A list of services with the respective status will be displayed.
+
+## Troubleshooting
+
+See the logs of each service with the following commands.
+
+```bash
+cd DIR_NAME
+sudo docker-compose logs -f SERVICE_NAME
+```
+
+Replace the term ``DIR_NAME`` with the service directory.
+
+The term ``SERVICE_NAME`` must be replaced with the name of the service whose logs you want to see.
+
+Restart the service with the following commands.
+
+```bash
+cd DIR_NAME
+sudo docker-compose restart SERVICE_NAME
+```
+
+Stop the service with the following commands.
+
+```bash
+cd DIR_NAME
+sudo docker-compose stop SERVICE_NAME
+```
+
+Start the service again with the following commands.
+
+```bash
+cd DIR_NAME
+sudo docker-compose start SERVICE_NAME
+```
+
+If you want to stop the service and remove all data, volume, images and container networks, use the following command (only if you really need to).
+
+```bash
+cd DIR_NAME
+sudo docker-compose -f SERVICE_NAME.yaml down
+```

--- a/compose/modules/README_es.md
+++ b/compose/modules/README_es.md
@@ -1,0 +1,146 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# API-Platform Híbrido - Docker Compose Modules
+
+En este método, todos los módulos se pueden instanciar por separado.
+
+## Requisitos
+
+Acceder a la sección **Requisitos** en [esta página](../README.md) para obtener información sobre como instalar las dependencias para el funcionamiento de los módulos.
+
+# Despliegue
+
+## Instalación
+
+### Logstash
+
+* Editar el archivo ``logstash-federated/logstash.env`` y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno.
+
+* Editar el archivo ``logstash-federated/logstash-federated.yaml`` y cambiar la version del módulo según las instrucciones de la sección **Cambio de Versión de los Módulos, Puerto de Red y Otros Parámetros** de [esta página](../README.md).
+
+* Ejecutar el servicio usando ``docker-compose`` con el siguiente comando.
+
+```bash
+sudo docker-compose -f logstash-federated/logstash-federated.yaml up -d
+```
+
+### Agent-Authorization
+
+* Editar el archivo ``agent-authorization/agent-authorization.env`` y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno.
+
+* Crear un token de acceso del entorno híbrido en el API-Manager según  las instrucciones de la sección **Creación de Token** de [esta página](../README.md).
+
+* Editar el archivo ``agent-authorization/agent-authorization.yaml`` y cambiar la version del módulo según las instrucciones de la sección **Cambio de Versión de los Módulos, Puerto de Red y Otros Parámetros** de [esta página](../README.md).
+
+* Ejecutar el servicio usando ``docker-compose`` con el siguiente comando.
+
+```bash
+sudo docker-compose -f agent-authorization.yaml up -d
+```
+
+### Agent-Gateway
+
+* Editar el archivo ``agent-gateway/agent-gateway.env`` y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno.
+
+* Crear un token de acceso del entorno híbrido en el API-Manager según  las instrucciones de la sección **Creación de Token** de [esta página](../README.md).
+
+* Editar el archivo ``agent-gateway/agent-gateway.yaml`` y cambiar la version del módulo según las instrucciones de la sección **Cambio de Versión de los Módulos, Puerto de Red y Otros Parámetros** de [esta página](../README.md).
+
+* Ejecutar el servicio usando ``docker-compose`` con el siguiente comando.
+
+```bash
+sudo docker-compose -d -f agent-gateway/agent-gateway.yaml up
+```
+
+### API-Authorization
+
+* Editar el archivo ``api-authorization/api-authorization.env`` y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno.
+
+* Editar el archivo ``api-authorization/api-authorization.yaml`` y cambiar la version del módulo según las instrucciones de la sección **Cambio de Versión de los Módulos, Puerto de Red y Otros Parámetros** de [esta página](../README.md).
+
+* Ejecutar el servicio usando ``docker-compose`` con el siguiente comando.
+
+```bash
+sudo docker-compose -f api-authorization/api-authorization.yaml up -d
+```
+
+### API-Gateway
+
+* Editar el archivo ``api-gateway/api-gateway.env`` y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno.
+
+* Editar el archivo ``api-gateway/api-gateway.yaml`` y cambiar la version del módulo según las instrucciones de la sección **Cambio de Versión de los Módulos, Puerto de Red y Otros Parámetros** de [esta página](../README.md).
+
+* Ejecutar el servicio usando ``docker-compose`` con el siguiente comando.
+
+```bash
+sudo docker-compose -f api-gateway/api-gateway.yaml up -d
+```
+
+## Validación
+
+Verificar el estatus de los contenedores con el siguiente comando.
+
+```bash
+sudo docker-compose -f NOME_DIR/NOME_COMPOSE_FILE ps
+```
+
+Sustituir el término ``NOME_DIR`` por el directorio del servicio.
+
+Sustituir el término ``NOME_COMPOSE_FILE`` por el archivo del servicio.
+
+Se mostrará una lista de servicios con el estatus correspondiente.
+
+## Solución de problemas
+
+Verificar los registros de cada servicio con los siguientes comandos.
+
+```bash
+cd NOME_DIR
+sudo docker-compose logs -f SERVICE_NAME
+```
+
+Sustituir el término ``NOME_DIR`` por el directorio del servicio.
+
+Sustituir el término ``SERVICE_NAME`` por el nombre del servicio cuyo registro se quiere ver.
+
+Reiniciar el servicio con los siguientes comandos.
+
+```bash
+cd NOME_DIR
+sudo docker-compose restart SERVICE_NAME
+```
+
+Parar el servicio con los siguientes comandos.
+
+```bash
+cd NOME_DIR
+sudo docker-compose stop SERVICE_NAME
+```
+
+Iniciar el servicio una vez más con los siguientes comandos.
+
+```bash
+cd NOME_DIR
+sudo docker-compose start SERVICE_NAME
+```
+
+Se quiere parar el servicio y quitar todos los dados, volúmenes, imágenes, red de contenedores, usar el siguiente comando (usar sólo si realmente necesario).
+
+```bash
+cd NOME_DIR
+sudo docker-compose -f SERVICE_NAME.yaml down
+```


### PR DESCRIPTION
…one/README(es/en)

**O que foi feito?**

Traduzidos para espanhol e inglês os README.md de compose/modules

Também foram corrigidas duas linhas com erro de digitação nos readme.md de compose/all-in-one




