### PR TITLE
add new version logstash federated

### DIFF
--- a/compose/all-in-one/hybrid.env
+++ b/compose/all-in-one/hybrid.env
@@ -14,6 +14,11 @@ SENSEDIA_APIPLATFORM_FEDERATED_PROXY_URL=https://integration-aws.sensedia.com
 SENSEDIA_APIPLATFORM_FEDERATED_CONNECT_TIMEOUT=10
 SENSEDIA_APIPLATFORM_FEDERATED_RETRIES=3
 
+#In case of using a proxy, fill in the variable below
+#LS_PROXY
+#The default value of variable LS_PORT (bind logstash) is 8080, if necessary, change below:
+#LS_PORT
+
 #AGENTS PROPERTIES
 #Insert your customer id (provided by Sensedia)
 WEBSOCKET_CUSTOMERID=CHANGE_HERE

--- a/compose/all-in-one/sensedia-all-in-one.yaml
+++ b/compose/all-in-one/sensedia-all-in-one.yaml
@@ -18,7 +18,7 @@ services:
     env_file: hybrid.env
     networks:
       - api-platform
-    image: gcr.io/production-main-268117/logstash-federated:4.1.1.0
+    image: gcr.io/production-main-268117/logstash-federated:4.1.2.0
     container_name: logstash-federated
     cpu_count: 1
     mem_limit: 1024M

--- a/compose/modules/logstash-federated/logstash-federated.env
+++ b/compose/modules/logstash-federated/logstash-federated.env
@@ -14,3 +14,8 @@ SENSEDIA_APIPLATFORM_FEDERATED_PROXY_URL=https://integration-aws.sensedia.com
 
 SENSEDIA_APIPLATFORM_FEDERATED_CONNECT_TIMEOUT=10
 SENSEDIA_APIPLATFORM_FEDERATED_RETRIES=3
+
+#In case of using a proxy, fill in the variable below
+#LS_PROXY
+#The default value of variable LS_PORT (bind logstash) is 8080, if necessary, change below:
+#LS_PORT

--- a/compose/modules/logstash-federated/logstash-federated.yaml
+++ b/compose/modules/logstash-federated/logstash-federated.yaml
@@ -5,7 +5,7 @@ services:
     env_file: logstash-federated.env
     networks:
       - api-platform
-    image: gcr.io/production-main-268117/logstash-federated:4.1.1.0
+    image: gcr.io/production-main-268117/logstash-federated:4.1.2.0
     container_name: logstash-federated
     cpu_count: 1
     mem_limit: 1024M

--- a/kubernetes/helm/values_examples/logstash-federated/values.yaml
+++ b/kubernetes/helm/values_examples/logstash-federated/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
  
 image:
   repository: gcr.io/production-main-268117/logstash-federated
-  tag: 4.1.1.0
+  tag: 4.1.2.0
   pullPolicy: IfNotPresent
  
 service:
@@ -22,6 +22,9 @@ properties:
   #apiplatform_proxy_url: "https://integration-production-gcp.sensedia.com"
   apiplatform_connect_timeout: "10"
   apiplatform_retries: "3"
+  ls_proxy: ""
+  #--- The default value of variable ls_bind_port (bind logstash) is 8080, if necessary, change below:
+  #ls_bind_port: ""
  
 autoscaling:
   enabled: false


### PR DESCRIPTION
**O que foi feito?**
Inclusão de nova versão do módulo Logstash Federated no ambiente hibrido.
Novas env vars:
**LS_PROXY
LS_PORT**

**Por que foi feito?**
Para suportar nova versão do módulo (4.1.2.0) em ambiente hibridos.
Novas env vars:
**LS_PROXY**: Utilizada em casos que o cliente utilizar proxy.
**LS_PORT**: O valor _default_ desta variavel é "8080", caso queira mudar a porta de _bind_ do serviço, basta descomentar esta var e inserir o valor desejado.

