### PR TITLE
Ajuste valor tag

### DIFF
--- a/kubernetes/README_es.md
+++ b/kubernetes/README_es.md
@@ -306,7 +306,7 @@ Ejemplo 1: Contenido del archivo ``values.yaml`` del módulo **Agent Authorizati
 replicaCount: 1
 image:
   repository: gcr.io/production-main-268117/agent-authorization
-  tag: 1909.1.1.2
+  tag: $versión reportada por el equipo de soporte
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP

--- a/kubernetes/README_es.md
+++ b/kubernetes/README_es.md
@@ -306,7 +306,7 @@ Ejemplo 1: Contenido del archivo ``values.yaml`` del módulo **Agent Authorizati
 replicaCount: 1
 image:
   repository: gcr.io/production-main-268117/agent-authorization
-  tag: $versión reportada por el equipo de soporte
+  tag: "CHANGE_HERE"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP


### PR DESCRIPTION
Alterado versão de exemplo para frase CHANGE_HERE

**O que foi feito?**
ajustado parametro da tag para frase : vCHANGE_HERE

**Por que foi feito?**
POis cliente estava inserindo a mesma senha do documento

