### PR TITLE
Update README.md

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -306,7 +306,7 @@ Exemplo 1: Conteúdo do arquivo ``values.yaml`` do módulo **Agent Authorization
 replicaCount: 1
 image:
   repository: gcr.io/production-main-268117/agent-authorization
-  tag: 1909.1.1.2
+  tag: "CHANGE_HERE"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP


### PR DESCRIPTION
O que foi feito?
ajustado parâmetro da tag para frase : vCHANGE_HERE

Por que foi feito?
Pois cliente estava inserindo a mesma senha do documento.