### PR TITLE
Update README_en.md

### DIFF
--- a/kubernetes/README_en.md
+++ b/kubernetes/README_en.md
@@ -308,7 +308,7 @@ Example 1. Content of the ``values.yaml`` file of the **Agent Authorization** mo
 replicaCount: 1
 image:
   repository: gcr.io/production-main-268117/agent-authorization
-  tag: 1909.1.1.2
+  tag: "CHANGE_HERE"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP


### PR DESCRIPTION
O que foi feito?
ajustado parâmetro da tag para frase : CHANGE_HERE

Por que foi feito?
Pois cliente estava inserindo a mesma senha do documento