### PR TITLE
docs: hybrid docs audit round 1 — Helm chart versions, values.yaml examples, compose fixes, broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Nesse caso, existe a possibilidade de que alguns componentes da topologia do API
       - [Docker](compose/README.md#docker)
       - [Docker-Compose](compose/README.md#docker-compose)
       - [Selinux no CentOS/Red Hat](compose/README.md#selinux-no-centosred-hat)
+      - [Redis](compose/README.md#redis)
     - [Métodos de Deploy](compose/README.md#métodos-de-deploy)
       - [Módulos](compose/README.md#módulos)
       - [Recursos Recomendados](compose/README.md#recursos-recomendados)
@@ -129,7 +130,7 @@ In this case, there is a possibility that some components of the API-Platform to
           - [Installation](compose/all-in-one/README_en.md#installation)
           - [Validation](compose/all-in-one/README_en.md#validation)
           - [Troubleshooting](compose/all-in-one/README_en.md#troubleshooting)
-        - [Segmented modules method](compose/modules/README_en.md#api-platform-híbrido---docker-compose-modules)
+        - [Segmented modules method](compose/modules/README_en.md#hybrid-api-platform---docker-compose-modules)
           - [Installation](compose/modules/README_en.md#installation)
             - [Logstash](compose/modules/README_en.md#logstash)
             - [Agent-Authorization](compose/modules/README_en.md#agent-authorization)
@@ -168,7 +169,7 @@ In this case, there is a possibility that some components of the API-Platform to
       - [Installing API-Authorization](kubernetes/README_en.md#installing-api-authorization)
       - [Installing API-Gateway](kubernetes/README_en.md#installing-api-gateway)
     - [Hybrid Environment Activation](kubernetes/README_en.md#hybrid-environment-activation)
-- [Monitoring](README_en.md#monitoring)
+- [Monitoring, health check and load balancing](README_en.md#monitoring-health-check-and-load-balancing)
 
 
 # Español

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
  </p>
 
 # Português
+> Última revisão: 2026-08-14
 
 **API-Platform**: plataforma de gerenciamento de APIs. Acelere suas estratégias digitais com integrações e gerenciamento de APIs. Saiba em: https://sensedia.com.
 
@@ -98,6 +99,7 @@ Nesse caso, existe a possibilidade de que alguns componentes da topologia do API
 <!-- TOC -->
 
 # English
+> Last reviewed: 2026-08-14
 
 **API-Platform**: API management platform. Accelerate your digital strategies with integrations and API Management. Learn more at: https://sensedia.com
 
@@ -173,6 +175,7 @@ In this case, there is a possibility that some components of the API-Platform to
 
 
 # Español
+> Última revisión: 2026-08-14
 
 **API-Platform**: plataforma de administración de APIs. Acelere sus estrategias digitales con integraciones y API Management. Obtenga más informaciónes en: https://sensedia.com.
 

--- a/README_en.md
+++ b/README_en.md
@@ -8,6 +8,7 @@
 <!-- TOC -->
 
 # English
+> Last reviewed: 2026-08-14
 
 ## Composition
 

--- a/README_es.md
+++ b/README_es.md
@@ -8,6 +8,7 @@
 <!-- TOC -->
 
 # Español
+> Última revisión: 2026-08-14
 
 ## Composición
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -8,6 +8,7 @@
 <!-- TOC -->
 
 # Português
+> Última revisão: 2026-08-14
 
 ## Composição
 

--- a/compose/README.md
+++ b/compose/README.md
@@ -197,21 +197,20 @@ Exemplo 1: Conteúdo do arquivo ``agent-gateway.yaml``.
 1   version: '2.4'
 2   services:
 3
-4     api-gateway:
-5       env_file: api-gateway.env  # você deve alterar o conteúdo desse arquivo conforme a documentação
+4     agent-gateway:
+5       env_file: agent-gateway.env  # você deve alterar o conteúdo desse arquivo conforme a documentação
 6       networks:
 7         - api-platform
-8       image: gcr.io/production-main-268117/api-gateway:4.3.0.2 # você pode alterar
-9       container_name: api-gateway
-10      cpu_count: 1      # você pode alterar
-11      mem_limit: 1024m  # você pode alterar
-12      restart: always
-13      ports:
-14        - '8080:8080'   #você pode alterar
-15
-16  networks:
-17    api-platform:
-18      name: api-platform
+8       image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE # você deve alterar
+9       container_name: agent-gateway
+10      mem_limit: 512m  # você pode alterar
+11      restart: always
+12      ports:
+13        - '8091:8091'   #você pode alterar
+14
+15  networks:
+16    api-platform:
+17      name: api-platform
 ```
 
 Explicação do conteúdo do arquivo ``agent-gateway.yaml``.
@@ -224,29 +223,27 @@ Explicação do conteúdo do arquivo ``agent-gateway.yaml``.
 
 * A **linha 5** contém a localização do arquivo de variáveis de ambiente. O nome, localização e o conteúdo desse arquivo mudam de acordo com o módulo. **É necessário que você também edite esse arquivo e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente híbrido.**
 
-* As **linhas 6 e 7** contém uma referência para as **linhas 16 a 18**, que definem a rede Docker a ser usada pelo contêiner que executará esse módulo da plataforma. Você não precisa alterar o conteúdo dessa seção.
+* As **linhas 6 e 7** contém uma referência para as **linhas 15 a 17**, que definem a rede Docker a ser usada pelo contêiner que executará esse módulo da plataforma. Você não precisa alterar o conteúdo dessa seção.
 
-* A **linha 8** contém o endereço do Docker Registry (``gcr.io/production-main-268117``), imagem Docker do módulo da plataforma (``api-gateway``) e versão do módulo (``4.3.0.2``). **Você deve entrar em contato com o time da Sensedia para saber qual a URL do Docker Registry, nome da imagem docker do módulo e a versão que deve utilizar e alterar no arquivo ``*.yaml`` antes de fazer o deploy.**
+* A **linha 8** contém o endereço do Docker Registry (``gcr.io/production-main-268117``), a imagem Docker do módulo da plataforma (``agent-gateway``) e a versão do módulo, indicada pelo termo ``CHANGE_HERE``. **Você deve entrar em contato com o time da Sensedia para saber qual a URL do Docker Registry, nome da imagem docker do módulo e a versão que deve utilizar e alterar no arquivo ``*.yaml`` antes de fazer o deploy.**
 
 * A **linha 9** contém o nome do contêiner que executará o módulo da plataforma. Você não precisa alterar.
 
-* Na **linha 10** você pode definir quantas CPUs que o serviço executado no contêiner pode utilizar. Nem todos os módulos contém essa definição por padrão.
+* Na **linha 10** você pode definir o limite de memória RAM que o serviço executado no contêiner pode utilizar. Alguns módulos (ex.: ``api-gateway.yaml``, ``api-authorization.yaml``) também definem um limite de CPU através do parâmetro ``cpu_count``, ausente neste exemplo por não ser definido por padrão para o Agent Gateway.
 
-* Na **linha 11** você pode definir o limite de memória RAM que o serviço executado no contêiner pode utilizar. Nem todos os módulos contém essa definição por padrão.
+* Na **linha 11** é definida a política de restart do contêiner. **É recomendado manter o valor ``always``**, para que o contêiner seja reiniciado automaticamente em caso de problemas, evitando a necessidade de uma intervenção manual.
 
-* Na **linha 12** é definida a política de restart do contêiner. **É recomendado manter o valor ``always``**, para que o contêiner seja reiniciado automaticamente em caso de problemas, evitando a necessidade de uma intervenção manual.
+* A **linha 12** contém um palavra reservada da sintaxe nativa do Docker Compose, que indica o início de uma seção para definição das portas (por padrão TCP-*Transmission Control Protocol*) que serão utilizadas pelo contêiner.
 
-* A **linha 13** contém um palavra reservada da sintaxe nativa do Docker Compose, que indica o início de uma seção para definição das portas (por padrão TCP-*Transmission Control Protocol*) que serão utilizadas pelo contêiner.
-
-* A **linha 14** contém a porta a ser utilizada pelo host e pelo contêiner para permitir o acesso externo ao módulo da plataforma. As portas são definidas no seguinte padrão:
+* A **linha 13** contém a porta a ser utilizada pelo host e pelo contêiner para permitir o acesso externo ao módulo da plataforma. As portas são definidas no seguinte padrão:
 
 PORTA_HOST:PORTA_contêiner
 
-Exemplo 2: ``- '8080:8080'`` - a porta do host é 8080/TCP, que escutará as requisições e encaminhará para a porta do contêiner, que é 8080/TCP.
+Exemplo 2: ``- '8091:8091'`` - a porta do host é 8091/TCP, que escutará as requisições e encaminhará para a porta do contêiner, que é 8091/TCP.
 
 **A porta do host pode ser alterada** conforme a necessidade do seu ambiente, mas a porta do contêiner **não deve ser alterada**.
 
-Exemplo 3: ``- '80:8080'``. Neste caso, a porta do host é 80/TCP e a a porta do contêiner é 8080/TCP.
+Exemplo 3: ``- '80:8091'``. Neste caso, a porta do host é 80/TCP e a porta do contêiner é 8091/TCP.
 
     ATENÇÃO!!! A porta do contêiner não é acessível fora do host. Ela só é acessível dentro do host.
 
@@ -289,7 +286,7 @@ Edite o arquivo ``all-in-one/hybrid.env``, localize os seguintes parâmetros e s
 
 Quando o método de instalação for **Modules**:
 
-Edite os arquivos ``modules/logstash-federated/logstash.env``, ``modules/agent-gateway/agent-gateway.env`` e ``modules/agent-authorization/agent-authorization.env``, localize os seguintes parâmetros e substitua o termo ``CHANGE_HERE`` pelo token gerado anteriormente.
+Edite os arquivos ``modules/logstash-federated/logstash-federated.env``, ``modules/agent-gateway/agent-gateway.env`` e ``modules/agent-authorization/agent-authorization.env``, localize os seguintes parâmetros e substitua o termo ``CHANGE_HERE`` pelo token gerado anteriormente.
 
 * WEBSOCKET_SENSEDIAAUTH=CHANGE_HERE
 * SENSEDIA_APIPLATFORM_FEDERATED_ACCESSTOKEN=CHANGE_HERE

--- a/compose/README.md
+++ b/compose/README.md
@@ -19,6 +19,7 @@
 
 
 # API-Platform Híbrido - Docker Compose
+> Última revisão: 2026-08-14
 
 O modelo de deploy **Híbrido** é recomendado para clientes que têm preocupação com latência.
 
@@ -193,49 +194,49 @@ A seguir é mostrado o exemplo de um arquivo ``.yaml`` para deploy de um módulo
 
 Exemplo 1: Conteúdo do arquivo ``agent-gateway.yaml``.
 
-```bash
-1   version: '2.4'
-2   services:
-3
-4     agent-gateway:
-5       env_file: agent-gateway.env  # você deve alterar o conteúdo desse arquivo conforme a documentação
-6       networks:
-7         - api-platform
-8       image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE # você deve alterar
-9       container_name: agent-gateway
-10      mem_limit: 512m  # você pode alterar
-11      restart: always
-12      ports:
-13        - '8091:8091'   #você pode alterar
-14
-15  networks:
-16    api-platform:
-17      name: api-platform
+```yaml
+version: '2.4'
+services:
+
+  agent-gateway:
+    env_file: agent-gateway.env  # você deve alterar o conteúdo desse arquivo conforme a documentação
+    networks:
+      - api-platform
+    image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE # você deve alterar
+    container_name: agent-gateway
+    mem_limit: 512m  # você pode alterar
+    restart: always
+    ports:
+      - '8091:8091'   #você pode alterar
+
+networks:
+  api-platform:
+    name: api-platform
 ```
 
 Explicação do conteúdo do arquivo ``agent-gateway.yaml``.
 
-* Na **linha 1** é definida a versão do Docker Compose file. Este valor deve ser alterado apenas pelo time da Sensedia quando realmente for necessário, pois afeta a sintaxe de alguns parâmetros e palavras reservadas do arquivo, conforme mostra a documentação oficial do Docker Compose: https://docs.docker.com/compose/compose-file/.
+* O campo ``version`` define a versão do Docker Compose file. Este valor deve ser alterado apenas pelo time da Sensedia quando realmente for necessário, pois afeta a sintaxe de alguns parâmetros e palavras reservadas do arquivo, conforme mostra a documentação oficial do Docker Compose: https://docs.docker.com/compose/compose-file/.
 
-* A **linha 2** contém um palavra reservada da sintaxe nativa do Docker Compose, que indica o início de um conjunto de instruções para deploy de um ou mais módulos da plataforma.
+* ``services`` é uma palavra reservada da sintaxe nativa do Docker Compose, que indica o início de um conjunto de instruções para deploy de um ou mais módulos da plataforma.
 
-* A **linha 4** indica o nome de serviço correspondente a um dos módulos da plataforma.
+* O nome do serviço declarado logo abaixo de ``services`` (``agent-gateway``) corresponde a um dos módulos da plataforma.
 
-* A **linha 5** contém a localização do arquivo de variáveis de ambiente. O nome, localização e o conteúdo desse arquivo mudam de acordo com o módulo. **É necessário que você também edite esse arquivo e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente híbrido.**
+* O campo ``env_file`` contém a localização do arquivo de variáveis de ambiente. O nome, localização e o conteúdo desse arquivo mudam de acordo com o módulo. **É necessário que você também edite esse arquivo e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente híbrido.**
 
-* As **linhas 6 e 7** contém uma referência para as **linhas 15 a 17**, que definem a rede Docker a ser usada pelo contêiner que executará esse módulo da plataforma. Você não precisa alterar o conteúdo dessa seção.
+* O campo ``networks`` faz referência ao bloco ``networks`` ao final do arquivo, que define a rede Docker a ser usada pelo contêiner que executará esse módulo da plataforma. Você não precisa alterar o conteúdo dessa seção.
 
-* A **linha 8** contém o endereço do Docker Registry (``gcr.io/production-main-268117``), a imagem Docker do módulo da plataforma (``agent-gateway``) e a versão do módulo, indicada pelo termo ``CHANGE_HERE``. **Você deve entrar em contato com o time da Sensedia para saber qual a URL do Docker Registry, nome da imagem docker do módulo e a versão que deve utilizar e alterar no arquivo ``*.yaml`` antes de fazer o deploy.**
+* O campo ``image`` contém o endereço do Docker Registry (``gcr.io/production-main-268117``), a imagem Docker do módulo da plataforma (``agent-gateway``) e a versão do módulo, indicada pelo termo ``CHANGE_HERE``. **Você deve entrar em contato com o time da Sensedia para saber qual a URL do Docker Registry, nome da imagem docker do módulo e a versão que deve utilizar e alterar no arquivo ``*.yaml`` antes de fazer o deploy.**
 
-* A **linha 9** contém o nome do contêiner que executará o módulo da plataforma. Você não precisa alterar.
+* O campo ``container_name`` contém o nome do contêiner que executará o módulo da plataforma. Você não precisa alterar.
 
-* Na **linha 10** você pode definir o limite de memória RAM que o serviço executado no contêiner pode utilizar. Alguns módulos (ex.: ``api-gateway.yaml``, ``api-authorization.yaml``) também definem um limite de CPU através do parâmetro ``cpu_count``, ausente neste exemplo por não ser definido por padrão para o Agent Gateway.
+* O campo ``mem_limit`` define o limite de memória RAM que o serviço executado no contêiner pode utilizar. Alguns módulos (ex.: ``api-gateway.yaml``, ``api-authorization.yaml``) também definem um limite de CPU através do parâmetro ``cpu_count``, ausente neste exemplo por não ser definido por padrão para o Agent Gateway.
 
-* Na **linha 11** é definida a política de restart do contêiner. **É recomendado manter o valor ``always``**, para que o contêiner seja reiniciado automaticamente em caso de problemas, evitando a necessidade de uma intervenção manual.
+* O campo ``restart`` define a política de restart do contêiner. **É recomendado manter o valor ``always``**, para que o contêiner seja reiniciado automaticamente em caso de problemas, evitando a necessidade de uma intervenção manual.
 
-* A **linha 12** contém um palavra reservada da sintaxe nativa do Docker Compose, que indica o início de uma seção para definição das portas (por padrão TCP-*Transmission Control Protocol*) que serão utilizadas pelo contêiner.
+* ``ports`` é uma palavra reservada da sintaxe nativa do Docker Compose, que indica o início de uma seção para definição das portas (por padrão TCP-*Transmission Control Protocol*) que serão utilizadas pelo contêiner.
 
-* A **linha 13** contém a porta a ser utilizada pelo host e pelo contêiner para permitir o acesso externo ao módulo da plataforma. As portas são definidas no seguinte padrão:
+* O valor listado sob ``ports`` contém a porta a ser utilizada pelo host e pelo contêiner para permitir o acesso externo ao módulo da plataforma. As portas são definidas no seguinte padrão:
 
 PORTA_HOST:PORTA_contêiner
 

--- a/compose/README_en.md
+++ b/compose/README_en.md
@@ -19,6 +19,7 @@
 
 
 # Hybrid API-Platform - Docker Compose
+> Last reviewed: 2026-08-14
 
 The **Hybrid** deployment model is recommended for clients with latency concerns.
 
@@ -193,49 +194,49 @@ This is an example of a ``.yaml`` file to deploy a module, followed by an explan
 
 Example 1: Content of file ``agent-gateway.yaml``.
 
-```bash
-1   version: '2.4'
-2   services:
-3
-4     agent-gateway:
-5       env_file: agent-gateway.env  # you must alter the content of this file according to the documentation
-6       networks:
-7         - api-platform
-8       image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE # you must alter
-9       container_name: agent-gateway
-10      mem_limit: 512m  # you can alter
-11      restart: always
-12      ports:
-13        - '8091:8091'   #you can alter
-14
-15  networks:
-16    api-platform:
-17      name: api-platform
+```yaml
+version: '2.4'
+services:
+
+  agent-gateway:
+    env_file: agent-gateway.env  # you must alter the content of this file according to the documentation
+    networks:
+      - api-platform
+    image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE # you must alter
+    container_name: agent-gateway
+    mem_limit: 512m  # you can alter
+    restart: always
+    ports:
+      - '8091:8091'   #you can alter
+
+networks:
+  api-platform:
+    name: api-platform
 ```
 
 Explanation of the content of the file ``agent-gateway.yaml``.
 
-* **Line 1** defines the Docker Compose file version. This value must be altered by the Sensedia team only when absolutely necessary, since it affects the syntax of some parameters and reserved words in the file, as the Docker Compose official documentation shows: https://docs.docker.com/compose/compose-file/.
+* The ``version`` field defines the Docker Compose file version. This value must be altered by the Sensedia team only when absolutely necessary, since it affects the syntax of some parameters and reserved words in the file, as the Docker Compose official documentation shows: https://docs.docker.com/compose/compose-file/.
 
-* **Line 2** contains a reserved word of native Docker Compose syntax, which indicates the beginning of a set of instructions to deploy one or more Platform modules.
+* ``services`` is a reserved word of native Docker Compose syntax, which indicates the beginning of a set of instructions to deploy one or more Platform modules.
 
-* **Line 4** indicates the service name corresponding to one of the Platform modules.
+* The service name declared right below ``services`` (``agent-gateway``) corresponds to one of the Platform modules.
 
-* **Line 5** contain the location of the environment variables file. The name, location and content of this file change according to the module. **You must also edit this file and alter the values defined as **CHANGE_HERE** to values consistent with your hybrid environment.**
+* The ``env_file`` field contains the location of the environment variables file. The name, location and content of this file change according to the module. **You must also edit this file and alter the values defined as **CHANGE_HERE** to values consistent with your hybrid environment.**
 
-* **Lines 6 and 7** contain a reference to **lines 15 to 17**, which define the Docker network to be used by the container that will execute this Platform module. You don't have to change the content of this section.
+* The ``networks`` field references the ``networks`` block at the end of the file, which defines the Docker network to be used by the container that will execute this Platform module. You don't have to change the content of this section.
 
-* **Line 8** contains the Docker Registry (``gcr.io/production-main-268117``), the Docker image of the Platform module (``agent-gateway``), and the module version, indicated by the term ``CHANGE_HERE``. **You must get in touch with the Sensedia team to know which Docker Registry URL, module Docker image name and version you must use and modify in the ``*.yaml`` file before deployment.**
+* The ``image`` field contains the Docker Registry (``gcr.io/production-main-268117``), the Docker image of the Platform module (``agent-gateway``), and the module version, indicated by the term ``CHANGE_HERE``. **You must get in touch with the Sensedia team to know which Docker Registry URL, module Docker image name and version you must use and modify in the ``*.yaml`` file before deployment.**
 
-* **Line 9** contains the name of the container which will execute the Platform module. You don't need to change it.
+* The ``container_name`` field contains the name of the container which will execute the Platform module. You don't need to change it.
 
-* On **line 10**, you can define the RAM memory limit that the service running on the container can use. Some modules (e.g. ``api-gateway.yaml``, ``api-authorization.yaml``) also define a CPU limit via the ``cpu_count`` parameter, absent from this example since it isn't set by default for the Agent Gateway.
+* The ``mem_limit`` field defines the RAM memory limit that the service running on the container can use. Some modules (e.g. ``api-gateway.yaml``, ``api-authorization.yaml``) also define a CPU limit via the ``cpu_count`` parameter, absent from this example since it isn't set by default for the Agent Gateway.
 
-* **Line 11** defines the container restart policy. **We recommend setting the value to ``always``** so that the container restarts automatically in case of problems, thus avoiding the need for manual intervention.
+* The ``restart`` field defines the container restart policy. **We recommend setting the value to ``always``** so that the container restarts automatically in case of problems, thus avoiding the need for manual intervention.
 
-* **Line 12** contains a reserved word of native Docker Compose syntax, which indicates the beginning of a section to define the ports (TCP - Transmission Control Protocol - by default) that will be used by the container.
+* ``ports`` is a reserved word of native Docker Compose syntax, which indicates the beginning of a section to define the ports (TCP - Transmission Control Protocol - by default) that will be used by the container.
 
-* **Line 13** contains the port to be used by the host and by the container to allow external access to the Platform module. The ports are defined following this pattern:
+* The value listed under ``ports`` contains the port to be used by the host and by the container to allow external access to the Platform module. The ports are defined following this pattern:
 
 PORT_HOST:PORT_container
 

--- a/compose/README_en.md
+++ b/compose/README_en.md
@@ -197,21 +197,20 @@ Example 1: Content of file ``agent-gateway.yaml``.
 1   version: '2.4'
 2   services:
 3
-4     api-gateway:
-5       env_file: api-gateway.env  # you must alter the content of this file according to the documentation
+4     agent-gateway:
+5       env_file: agent-gateway.env  # you must alter the content of this file according to the documentation
 6       networks:
 7         - api-platform
-8       image: gcr.io/production-main-268117/api-gateway:4.3.0.2 # you can alter
-9       container_name: api-gateway
-10      cpu_count: 1      # you can alter
-11      mem_limit: 1024m  # you can alter
-12      restart: always
-13      ports:
-14        - '8080:8080'   #you can alter
-15
-16  networks:
-17    api-platform:
-18      name: api-platform
+8       image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE # you must alter
+9       container_name: agent-gateway
+10      mem_limit: 512m  # you can alter
+11      restart: always
+12      ports:
+13        - '8091:8091'   #you can alter
+14
+15  networks:
+16    api-platform:
+17      name: api-platform
 ```
 
 Explanation of the content of the file ``agent-gateway.yaml``.
@@ -224,29 +223,27 @@ Explanation of the content of the file ``agent-gateway.yaml``.
 
 * **Line 5** contain the location of the environment variables file. The name, location and content of this file change according to the module. **You must also edit this file and alter the values defined as **CHANGE_HERE** to values consistent with your hybrid environment.**
 
-* **Lines 6 and 7** contain a reference to **lines 16 to 18**, which define the Docker network to be used by the container that will execute this Platform module. You don't have to change the content of this section.
+* **Lines 6 and 7** contain a reference to **lines 15 to 17**, which define the Docker network to be used by the container that will execute this Platform module. You don't have to change the content of this section.
 
-* **Line 8** contains the Docker Registry (``gcr.io/production-main-268117``), Docker image of the Platform module (``api-gateway``) and module version (``4.3.0.2``). **You must get in touch with the Sensedia team to know which Docker Registry URL, module Docker image name and version you must use and modify in the ``*.yaml`` file before deployment.**
+* **Line 8** contains the Docker Registry (``gcr.io/production-main-268117``), the Docker image of the Platform module (``agent-gateway``), and the module version, indicated by the term ``CHANGE_HERE``. **You must get in touch with the Sensedia team to know which Docker Registry URL, module Docker image name and version you must use and modify in the ``*.yaml`` file before deployment.**
 
 * **Line 9** contains the name of the container which will execute the Platform module. You don't need to change it.
 
-* On **line 10**, you can define how many CPUs the service running on the container can use. Not all modules have this definition as a default.
+* On **line 10**, you can define the RAM memory limit that the service running on the container can use. Some modules (e.g. ``api-gateway.yaml``, ``api-authorization.yaml``) also define a CPU limit via the ``cpu_count`` parameter, absent from this example since it isn't set by default for the Agent Gateway.
 
-* On **line 11**, you can define the RAM memory limit that the service running on the container can use. Not all modules have this definition as a default.
+* **Line 11** defines the container restart policy. **We recommend setting the value to ``always``** so that the container restarts automatically in case of problems, thus avoiding the need for manual intervention.
 
-* **Line 12** defines the container restart policy. **We recommend setting the value to ``always``** so that the container restarts automatically in case of problems, thus avoiding the need for manual intervention.
+* **Line 12** contains a reserved word of native Docker Compose syntax, which indicates the beginning of a section to define the ports (TCP - Transmission Control Protocol - by default) that will be used by the container.
 
-* **Line 13** contains a reserved word of native Docker Compose syntax, which indicates the beginning of a section to define the ports (TCP - Transmission Control Protocol - by default) that will be used by the container.
-
-* **Line 14** contains the port to be used by the host and by the container to allow external access to the Platform module. The ports are defined following this pattern:
+* **Line 13** contains the port to be used by the host and by the container to allow external access to the Platform module. The ports are defined following this pattern:
 
 PORT_HOST:PORT_container
 
-Example 2: ``- '8080:8080'`` - the host port is 8080/TCP, which will listen to requests and forward them to the container port, which is 8080/TCP.
+Example 2: ``- '8091:8091'`` - the host port is 8091/TCP, which will listen to requests and forward them to the container port, which is 8091/TCP.
 
 **The host port can be changed** as required by your environment, but the container port **should not be changed**.
 
-Example 3 ``- '80:8080'``. In this case, the host port is 80/TCP and the container port is 8080/TCP.
+Example 3 ``- '80:8091'``. In this case, the host port is 80/TCP and the container port is 8091/TCP.
 
 	ATTENTION!!! The container port is inaccessible from outside the host. It's only accessible from inside the host.
 
@@ -289,7 +286,7 @@ Edit the file ``all-in-one/hybrid.env``, find the following parameters and repla
 
 When the installation method is **Modules**:
 
-Edit the files ``modules/logstash-federated/logstash.env``, ``modules/agent-gateway/agent-gateway.env`` and ``modules/agent-authorization/agent-authorization.env``, find the following parameters and replace the term ``CHANGE_HERE`` with the token generated previously.
+Edit the files ``modules/logstash-federated/logstash-federated.env``, ``modules/agent-gateway/agent-gateway.env`` and ``modules/agent-authorization/agent-authorization.env``, find the following parameters and replace the term ``CHANGE_HERE`` with the token generated previously.
 
 * WEBSOCKET_SENSEDIAAUTH=CHANGE_HERE
 * SENSEDIA_APIPLATFORM_FEDERATED_ACCESSTOKEN=CHANGE_HERE

--- a/compose/README_es.md
+++ b/compose/README_es.md
@@ -19,6 +19,7 @@
 
 
 # API-Platform Híbrido - Docker Compose
+> Última revisión: 2026-08-14
 
 El modelo de implantación **Híbrido** se recomienda para los clientes que tienen problemas de latencia.
 
@@ -193,49 +194,49 @@ Este es un ejemplo de un archivo ``.yaml`` para desplegar un módulo, seguido de
 
 Ejemplo 1: Contenido del archivo ``agent-gateway.yaml``.
 
-```bash
-1   version: '2.4'
-2   services:
-3
-4     agent-gateway:
-5       env_file: agent-gateway.env  # deve cambiar el contenido de este archivo de acuerdo con la documentación
-6       networks:
-7         - api-platform
-8       image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE # deve cambiar
-9       container_name: agent-gateway
-10      mem_limit: 512m  # puede cambiar
-11      restart: always
-12      ports:
-13        - '8091:8091'   #puede cambiar
-14
-15  networks:
-16    api-platform:
-17      name: api-platform
+```yaml
+version: '2.4'
+services:
+
+  agent-gateway:
+    env_file: agent-gateway.env  # deve cambiar el contenido de este archivo de acuerdo con la documentación
+    networks:
+      - api-platform
+    image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE # deve cambiar
+    container_name: agent-gateway
+    mem_limit: 512m  # puede cambiar
+    restart: always
+    ports:
+      - '8091:8091'   #puede cambiar
+
+networks:
+  api-platform:
+    name: api-platform
 ```
 
 Explicación del contenido del archivo ``agent-gateway.yaml``.
 
-* Na **línea 1** se define la versión del archivo Docker Compose. Este valor sólo deve ser cambiado por el equipo de Sensedia cuando sea realmente necesario, pues que afecta a la sintaxis de algunos parámetros y palavras reservadas del archivo, tal y como establece la documentación oficial de Docker Compose: https://docs.docker.com/compose/compose-file/.
+* El campo ``version`` define la versión del archivo Docker Compose. Este valor sólo deve ser cambiado por el equipo de Sensedia cuando sea realmente necesario, pues que afecta a la sintaxis de algunos parámetros y palavras reservadas del archivo, tal y como establece la documentación oficial de Docker Compose: https://docs.docker.com/compose/compose-file/.
 
-* La **línea 2** contiene una palabra reservada de la sintaxis nativa de Docker Compose, que indica el comienzo de un conjunto de instrucciones para desplegar uno o más módulos de la Plataforma.
+* ``services`` es una palabra reservada de la sintaxis nativa de Docker Compose, que indica el comienzo de un conjunto de instrucciones para desplegar uno o más módulos de la Plataforma.
 
-* La **línea 4** indica el nombre de servicio correspondiente a uno de los módulos de la Plataforma.
+* El nombre de servicio declarado justo debajo de ``services`` (``agent-gateway``) corresponde a uno de los módulos de la Plataforma.
 
-* La **línea 5** contiene la ubicación del archivo de variables de entorno. El nombre, la ubicación y el contenido de este archivo cambian según el módulo. **También debe editar este archivo y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno híbrido.**
+* El campo ``env_file`` contiene la ubicación del archivo de variables de entorno. El nombre, la ubicación y el contenido de este archivo cambian según el módulo. **También debe editar este archivo y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno híbrido.**
 
-* Las **líneas 6 y 7** contienen una referencia a las **líneas 15 a 17**, que definen una red Docker para ser utilizada por el contenedor que ejecutará este módulo de la Plataforma. No tiene que cambiar el contenido de esta sección.
+* El campo ``networks`` hace referencia al bloque ``networks`` al final del archivo, que define una red Docker para ser utilizada por el contenedor que ejecutará este módulo de la Plataforma. No tiene que cambiar el contenido de esta sección.
 
-* La **línea 8** contiene la dirección del Docker Registry (``gcr.io/production-main-268117``), la imagen Docker del módulo de la Plataforma (``agent-gateway``) y la versión del módulo, indicada por el término ``CHANGE_HERE``. **Debe contactar con el equipo de Sensedia para averiguar qué URL de Docker Registry, nombre de imagen Docker del módulo y la versión que se debe utilizar y cambiar en el archivo ``*.yaml`` antes del despliegue.**
+* El campo ``image`` contiene la dirección del Docker Registry (``gcr.io/production-main-268117``), la imagen Docker del módulo de la Plataforma (``agent-gateway``) y la versión del módulo, indicada por el término ``CHANGE_HERE``. **Debe contactar con el equipo de Sensedia para averiguar qué URL de Docker Registry, nombre de imagen Docker del módulo y la versión que se debe utilizar y cambiar en el archivo ``*.yaml`` antes del despliegue.**
 
-* La **línea 9** contiene el nombre del contenedor que ejecutará el módulo de la Plataforma. No tiene que cambiarla.
+* El campo ``container_name`` contiene el nombre del contenedor que ejecutará el módulo de la Plataforma. No tiene que cambiarla.
 
-* En la **línea 10** se puede definir el límite de memoria RAM que puede usar el servicio que funciona en el contenedor. Algunos módulos (ej.: ``api-gateway.yaml``, ``api-authorization.yaml``) también definen un límite de CPU mediante el parámetro ``cpu_count``, ausente en este ejemplo porque no se define por defecto para el Agent Gateway.
+* El campo ``mem_limit`` define el límite de memoria RAM que puede usar el servicio que funciona en el contenedor. Algunos módulos (ej.: ``api-gateway.yaml``, ``api-authorization.yaml``) también definen un límite de CPU mediante el parámetro ``cpu_count``, ausente en este ejemplo porque no se define por defecto para el Agent Gateway.
 
-* En la **línea 11** se define la política de reinicio del contenedor. **Se recomienda mantener el valor ``always``** para que el contenedor se reinicie automáticamente en caso de problemas, evitando la necesidad de intervención manual.
+* El campo ``restart`` define la política de reinicio del contenedor. **Se recomienda mantener el valor ``always``** para que el contenedor se reinicie automáticamente en caso de problemas, evitando la necesidad de intervención manual.
 
-* La **línea 12** contiene una palabra reservada de la sintaxis nativa de Docker Compose, que indica el comienzo de una sección para definir los puertos (por defecto, TCP - Transmission Control Protocol) que serán utilizados por el contenedor.
+* ``ports`` es una palabra reservada de la sintaxis nativa de Docker Compose, que indica el comienzo de una sección para definir los puertos (por defecto, TCP - Transmission Control Protocol) que serán utilizados por el contenedor.
 
-La **línea 13** contiene el puerto que utilizará el host y el contenedor para permitir acceso externo ao módulo de la Plataforma. Los puertos están definidos por la siguiente norma:
+* El valor listado bajo ``ports`` contiene el puerto que utilizará el host y el contenedor para permitir acceso externo al módulo de la Plataforma. Los puertos están definidos por la siguiente norma:
 
 PUERTO_HOST:PUERTO_contenedor
 

--- a/compose/README_es.md
+++ b/compose/README_es.md
@@ -197,21 +197,20 @@ Ejemplo 1: Contenido del archivo ``agent-gateway.yaml``.
 1   version: '2.4'
 2   services:
 3
-4     api-gateway:
-5       env_file: api-gateway.env  # deve cambiar el contenido de este archivo de acuerdo con la documentación
+4     agent-gateway:
+5       env_file: agent-gateway.env  # deve cambiar el contenido de este archivo de acuerdo con la documentación
 6       networks:
 7         - api-platform
-8       image: gcr.io/production-main-268117/api-gateway:4.3.0.2 # puede cambiar
-9       container_name: api-gateway
-10      cpu_count: 1      # puede cambiar
-11      mem_limit: 1024m  # puede cambiar
-12      restart: always
-13      ports:
-14        - '8080:8080'   #puede cambiar
-15
-16  networks:
-17    api-platform:
-18      name: api-platform
+8       image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE # deve cambiar
+9       container_name: agent-gateway
+10      mem_limit: 512m  # puede cambiar
+11      restart: always
+12      ports:
+13        - '8091:8091'   #puede cambiar
+14
+15  networks:
+16    api-platform:
+17      name: api-platform
 ```
 
 Explicación del contenido del archivo ``agent-gateway.yaml``.
@@ -224,29 +223,27 @@ Explicación del contenido del archivo ``agent-gateway.yaml``.
 
 * La **línea 5** contiene la ubicación del archivo de variables de entorno. El nombre, la ubicación y el contenido de este archivo cambian según el módulo. **También debe editar este archivo y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno híbrido.**
 
-* Las **líneas 6 y 7** contienen una referencia a las **líneas 16 a 18**, que definen una red Docker para ser utilizada por el contenedor que ejecutará este módulo de la Plataforma. No tiene que cambiar el contenido de esta sección.
+* Las **líneas 6 y 7** contienen una referencia a las **líneas 15 a 17**, que definen una red Docker para ser utilizada por el contenedor que ejecutará este módulo de la Plataforma. No tiene que cambiar el contenido de esta sección.
 
-* La **línea 8** contiene la dirección del Docker Registry (``gcr.io/production-main-268117``), imagen Docker del módulo de la Plataforma (``api-gateway``) y la versão del módulo (``4.3.0.2``). **Debe contactar con el equipo de Sensedia para averiguar qué URL de Docker Registry, nombre de imagen Docker del módulo y la versión que se debe utilizar y cambiar en el archivo ``*.yaml`` antes del despliegue.**
+* La **línea 8** contiene la dirección del Docker Registry (``gcr.io/production-main-268117``), la imagen Docker del módulo de la Plataforma (``agent-gateway``) y la versión del módulo, indicada por el término ``CHANGE_HERE``. **Debe contactar con el equipo de Sensedia para averiguar qué URL de Docker Registry, nombre de imagen Docker del módulo y la versión que se debe utilizar y cambiar en el archivo ``*.yaml`` antes del despliegue.**
 
 * La **línea 9** contiene el nombre del contenedor que ejecutará el módulo de la Plataforma. No tiene que cambiarla.
 
-* En la **línea 10** se puede definir cuántas CPUs puede usar el servicio que funciona en el contenedor. No todos los módulos contienen este ajuste por defecto.
+* En la **línea 10** se puede definir el límite de memoria RAM que puede usar el servicio que funciona en el contenedor. Algunos módulos (ej.: ``api-gateway.yaml``, ``api-authorization.yaml``) también definen un límite de CPU mediante el parámetro ``cpu_count``, ausente en este ejemplo porque no se define por defecto para el Agent Gateway.
 
-* En la **línea 11** se puede definir el límite de memoria RAM que puede usar el servicio que funciona en el contenedor. No todos los módulos contienen este ajuste por defecto.
+* En la **línea 11** se define la política de reinicio del contenedor. **Se recomienda mantener el valor ``always``** para que el contenedor se reinicie automáticamente en caso de problemas, evitando la necesidad de intervención manual.
 
-* En la **línea 12** se define la política de reinicio del contenedor. **Se recomienda mantener el valor ``always``** para que el contenedor se reinicie automáticamente en caso de problemas, evitando la necesidad de intervención manual.
-
-* La **línea 13** contiene una palabra reservada de la sintaxis nativa de Docker Compose, que indica el comienzo de una sección para definir los puertos (por defecto, TCP - Transmission Control Protocol) que serán utilizados por el contenedor.
+* La **línea 12** contiene una palabra reservada de la sintaxis nativa de Docker Compose, que indica el comienzo de una sección para definir los puertos (por defecto, TCP - Transmission Control Protocol) que serán utilizados por el contenedor.
 
 La **línea 13** contiene el puerto que utilizará el host y el contenedor para permitir acceso externo ao módulo de la Plataforma. Los puertos están definidos por la siguiente norma:
 
 PUERTO_HOST:PUERTO_contenedor
 
-Ejemplo 2: ``- '8080:8080'`` - el puerto de host es el 8080/TCP, que escuchará las peticiones y las reenviará al puerto del contenedor, que es el 8080/TCP.
+Ejemplo 2: ``- '8091:8091'`` - el puerto de host es el 8091/TCP, que escuchará las peticiones y las reenviará al puerto del contenedor, que es el 8091/TCP.
 
 **El puerto de host puede cambiarse** según lo requiera su entorno, pero el puerto del contenedor **no debe cambiarse**.
 
-Ejemplo 3: ``- '80:8080'``. En este caso, el puerto de host es el 80/TCP y el puerto del contenedor es el 8080/TCP.
+Ejemplo 3: ``- '80:8091'``. En este caso, el puerto de host es el 80/TCP y el puerto del contenedor es el 8091/TCP.
 
   ¡¡ATENCIÓN!! El puerto del contenedor no es accesible fuera del hist. Sólo se puede acceder a él dentro del host.
 
@@ -289,7 +286,7 @@ Editar el archivo ``all-in-one/hybrid.env``, ubicar los siguientes parámetros e
 
 Cuando el método de instalación sea **Modules**:
 
-Editar los archivos ``modules/logstash-federated/logstash.env``, ``modules/agent-gateway/agent-gateway.env`` y ``modules/agent-authorization/agent-authorization.env``, ubicar los siguientes parámetros e sustituir el término ``CHANGE_HERE`` por el token generado anteriormente.
+Editar los archivos ``modules/logstash-federated/logstash-federated.env``, ``modules/agent-gateway/agent-gateway.env`` y ``modules/agent-authorization/agent-authorization.env``, ubicar los siguientes parámetros e sustituir el término ``CHANGE_HERE`` por el token generado anteriormente.
 
 * WEBSOCKET_SENSEDIAAUTH=CHANGE_HERE
 * SENSEDIA_APIPLATFORM_FEDERATED_ACCESSTOKEN=CHANGE_HERE

--- a/compose/all-in-one/README.md
+++ b/compose/all-in-one/README.md
@@ -11,6 +11,7 @@
 <!-- TOC -->
 
 # All-in-one deployment method
+> Última revisão: 2026-08-14
 
 Este método de deployment inicia todos os módulos *stateless* da plataforma no mesmo host.
 

--- a/compose/all-in-one/README_en.md
+++ b/compose/all-in-one/README_en.md
@@ -11,6 +11,7 @@
 <!-- TOC END -->
 
 # All-in-one deployment method
+> Last reviewed: 2026-08-14
 
 This deployment method starts all Platform's stateless modules on the same host.
 

--- a/compose/all-in-one/README_es.md
+++ b/compose/all-in-one/README_es.md
@@ -11,6 +11,7 @@
 <!-- TOC END -->
 
 # Método de despliegue All-in-one
+> Última revisión: 2026-08-14
 
 Este método de despliegue inicia todos los módulos *stateless* de la Plataforma en el mismo host.
 

--- a/compose/modules/README.md
+++ b/compose/modules/README.md
@@ -15,6 +15,7 @@
 <!-- TOC -->
 
 # API-Platform Híbrido - Docker Compose Modules
+> Última revisão: 2026-08-14
 
 Neste método, cada módulo pode ser instanciado separadamente.
 

--- a/compose/modules/README.md
+++ b/compose/modules/README.md
@@ -28,7 +28,7 @@ Acesse [essa página](../README.md), na seção **Requisitos**, para obter infor
 
 ### Logstash
 
-* Edite o arquivo ``logstash-federated/logstash.env`` e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente.
+* Edite o arquivo ``logstash-federated/logstash-federated.env`` e altere os valores definidos como **CHANGE_HERE** para os valores condizentes com seu ambiente.
 
 * Edite o arquivo ``logstash-federated/logstash-federated.yaml`` e altere a versão do módulo, conforme as instruções [dessa página](../README.md), na seção **Alterando a Versão dos Módulos, Porta e Outros Parâmetros**.
 

--- a/compose/modules/README_en.md
+++ b/compose/modules/README_en.md
@@ -28,7 +28,7 @@ Access the **Requirements** section of [this page](../README.md) to read on how 
 
 ### Logstash
 
-* Edit the file ``logstash-federated/logstash.env`` and replace the values defines as **CHANGE_HERE** with values consistent with your environment.
+* Edit the file ``logstash-federated/logstash-federated.env`` and replace the values defines as **CHANGE_HERE** with values consistent with your environment.
 
 * Edit the file ``logstash-federated/logstash-federated.yaml`` and change the module version, according to the instructions on the **Changing Modules Version, Port and Other Parameters** section of [this page](../README.md).
 

--- a/compose/modules/README_en.md
+++ b/compose/modules/README_en.md
@@ -15,6 +15,7 @@
 <!-- TOC -->
 
 # Hybrid API-Platform - Docker Compose Modules
+> Last reviewed: 2026-08-14
 
 In this method, each module can be instanced separately.
 

--- a/compose/modules/README_es.md
+++ b/compose/modules/README_es.md
@@ -28,7 +28,7 @@ Acceder a la sección **Requisitos** en [esta página](../README.md) para obtene
 
 ### Logstash
 
-* Editar el archivo ``logstash-federated/logstash.env`` y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno.
+* Editar el archivo ``logstash-federated/logstash-federated.env`` y cambiar los valores que contienen **CHANGE_HERE** a valores consistentes con su entorno.
 
 * Editar el archivo ``logstash-federated/logstash-federated.yaml`` y cambiar la version del módulo según las instrucciones de la sección **Cambio de Versión de los Módulos, Puerto de Red y Otros Parámetros** de [esta página](../README.md).
 

--- a/compose/modules/README_es.md
+++ b/compose/modules/README_es.md
@@ -15,6 +15,7 @@
 <!-- TOC -->
 
 # API-Platform Híbrido - Docker Compose Modules
+> Última revisión: 2026-08-14
 
 En este método, todos los módulos se pueden instanciar por separado.
 

--- a/compose/modules/agent-authorization/agent-authorization.env
+++ b/compose/modules/agent-authorization/agent-authorization.env
@@ -12,7 +12,7 @@ WEBSOCKET_URI=wss://integration-aws.sensedia.com/websocket
 #--- If client in GCP
 #WEBSOCKET_URI=wss://integration-production-gcp.sensedia.com/websocket
 
-REDIS_ADDRESS=CHANGE_HERE. #Example: redis.endpoint:6379,redis.endpoint2:6379,redis.endpoint3:6379
+REDIS_ADDRESS=CHANGE_HERE #Example: redis.endpoint:6379,redis.endpoint2:6379,redis.endpoint3:6379
 #Insert your REDIS SCENARIO CONNECTION TYPE. Would be STANDALONE, MASTER_SLAVE or even CLUSTER
 REDIS_CONNECTIONTYPE=CHANGE_HERE
 REDIS_COMPRESSDATA=true

--- a/compose/modules/agent-authorization/agent-authorization.yaml
+++ b/compose/modules/agent-authorization/agent-authorization.yaml
@@ -5,7 +5,7 @@ services:
     env_file: agent-authorization.env
     networks:
       - api-platform
-    image: gcr.io/production-main-268117/agent-authorization:#CHANGE_HERE
+    image: gcr.io/production-main-268117/agent-authorization:CHANGE_HERE
     container_name: agent-authorization
     mem_limit: 512m
     restart: always

--- a/compose/modules/agent-gateway/agent-gateway.env
+++ b/compose/modules/agent-gateway/agent-gateway.env
@@ -12,7 +12,7 @@ WEBSOCKET_URI=wss://integration-aws.sensedia.com/websocket
 #--- If client in GCP
 #WEBSOCKET_URI=wss://integration-production-gcp.sensedia.com/websocket
 
-REDIS_ADDRESS=CHANGE_HERE. #Example: redis.endpoint:6379,redis.endpoint2:6379,redis.endpoint3:6379
+REDIS_ADDRESS=CHANGE_HERE #Example: redis.endpoint:6379,redis.endpoint2:6379,redis.endpoint3:6379
 #Insert your REDIS SCENARIO CONNECTION TYPE. Would be STANDALONE, MASTER_SLAVE or even CLUSTER
 REDIS_CONNECTIONTYPE=CHANGE_HERE
 REDIS_COMPRESSDATA=true

--- a/compose/modules/agent-gateway/agent-gateway.yaml
+++ b/compose/modules/agent-gateway/agent-gateway.yaml
@@ -5,7 +5,7 @@ services:
     env_file: agent-gateway.env
     networks:
       - api-platform
-    image: gcr.io/production-main-268117/agent-gateway:#CHANGE_HERE
+    image: gcr.io/production-main-268117/agent-gateway:CHANGE_HERE
     container_name: agent-gateway
     mem_limit: 512m
     restart: always

--- a/compose/modules/api-authorization/api-authorization.yaml
+++ b/compose/modules/api-authorization/api-authorization.yaml
@@ -5,7 +5,7 @@ services:
     env_file: api-authorization.env
     networks:
       - api-platform
-    image: gcr.io/production-main-268117/api-authorization:#CHANGE_HERE
+    image: gcr.io/production-main-268117/api-authorization:CHANGE_HERE
     container_name: api-authorization
     mem_limit: 2048m
     restart: always

--- a/compose/modules/api-gateway/api-gateway.yaml
+++ b/compose/modules/api-gateway/api-gateway.yaml
@@ -5,7 +5,7 @@ services:
     env_file: api-gateway.env
     networks:
       - api-platform
-    image: gcr.io/production-main-268117/api-gateway:#CHANGE_HERE
+    image: gcr.io/production-main-268117/api-gateway:CHANGE_HERE
     container_name: api-gateway
     cpu_count: 1
     mem_limit: 2048m

--- a/compose/modules/logstash-federated/logstash-federated.yaml
+++ b/compose/modules/logstash-federated/logstash-federated.yaml
@@ -5,7 +5,7 @@ services:
     env_file: logstash-federated.env
     networks:
       - api-platform
-    image: gcr.io/production-main-268117/logstash-federated:#CHANGE_HERE
+    image: gcr.io/production-main-268117/logstash-federated:CHANGE_HERE
     container_name: logstash-federated
     cpu_count: 1
     mem_limit: 1024M

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -32,6 +32,7 @@
 <!-- TOC -->
 
 # API-Platform Híbrido - Kubernetes
+> Última revisão: 2026-08-14
 
 O modelo de deploy Híbrido é recomendado para clientes que têm preocupação com latência. Esta documentação explica como realizar o deployment dos módulos/serviços utilizados no ambiente híbrido usando [Kubernetes](https://kubernetes.io) e [Helm](https://helm.sh).
 
@@ -399,13 +400,12 @@ Altere os valores definidos como ``CHANGE_HERE`` para os valores condizentes com
 
 Explicação do conteúdo do arquivo ``values.yaml`` do módulo **Agent Authorization**.
 
-* Na **linha 4** é definida a quantidade de réplicas do pod, que executam o módulo e que podem ser executadas no cluster Kubernetes. Altere o valor conforme a demanda e disponibilidade de recursos de CPU, memória e endereços IP.
-* A **linha 6** contém o endereço do Docker Registry e o nome da imagem Docker do respectivo módulo (``gcr.io/production-main-268117/agent-authorization``). Você deve entrar em contato com o time da Sensedia para saber qual a URL do Docker Registry, nome da imagem docker do módulo que deve utilizar e alterar no arquivo ``.yaml`` antes de fazer o deploy.
-* A **linha 7** contém a tag/versão da imagem Docker do módulo. Você deve entrar em contato com o time da Sensedia para saber qual a versão que deve utilizar e alterar no arquivo ``.yaml`` antes de fazer o deploy.
-* Das **linhas 14 a 24**, encontramos as informações referentes ao redis. Nesta sessão do yaml, é preciso alterar as informações de endereçamento do redis (``address``) e, caso necessário, aplicar uma senha de acesso (``password``, codificada em base64). Os parâmetros ``sslEnabled`` e ``sslVerifyPeer`` habilitam conexão TLS com o Redis. Os parâmetros ``masterSlaveReadFrom``, ``lettuceSentinelHosts``, ``lettuceSentinelMasterId`` e ``lettuceSentinelDefaultPort`` só se aplicam quando ``connectionType`` é ``MASTER_SLAVE`` e o Redis está configurado com Sentinel.
-* As **linhas 33 a 37** contém a definição de autoscaling para o pod. Altere conforme a demanda e a disponibilidade de recursos de hardware no cluster e de endereços IP.
-* As **linhas 38 a 44** contém a definição de ingress e TLS para o módulo. Altere conforme a necessidade do ambiente.
-* As **linhas 45 a 51** contém a definição dos limites de uso dos recursos de CPU e memória a serem utilizados por cada pod do módulo. Altere conforme a demanda e a disponibilidade de recursos de hardware no cluster.
+* O campo ``replicaCount`` define a quantidade de réplicas do pod que executam o módulo e que podem ser executadas no cluster Kubernetes. Altere o valor conforme a demanda e disponibilidade de recursos de CPU, memória e endereços IP.
+* Os campos ``image.repository`` e ``image.tag`` contêm, respectivamente, o endereço do Docker Registry e o nome da imagem Docker do respectivo módulo (``gcr.io/production-main-268117/agent-authorization``), e a tag/versão da imagem. Você deve entrar em contato com o time da Sensedia para saber qual a URL do Docker Registry, nome da imagem docker do módulo e a versão que deve utilizar, e alterar no arquivo ``.yaml`` antes de fazer o deploy.
+* O bloco ``properties.redis`` contém as informações referentes ao redis. É preciso alterar as informações de endereçamento (``address``) e, caso necessário, aplicar uma senha de acesso (``password``, codificada em base64). Os parâmetros ``sslEnabled`` e ``sslVerifyPeer`` habilitam conexão TLS com o Redis. Os parâmetros ``masterSlaveReadFrom``, ``lettuceSentinelHosts``, ``lettuceSentinelMasterId`` e ``lettuceSentinelDefaultPort`` só se aplicam quando ``connectionType`` é ``MASTER_SLAVE`` e o Redis está configurado com Sentinel.
+* O bloco ``autoscaling`` contém a definição de autoscaling para o pod. Altere conforme a demanda e a disponibilidade de recursos de hardware no cluster e de endereços IP.
+* O bloco ``ingress`` contém a definição de ingress e TLS para o módulo. Altere conforme a necessidade do ambiente.
+* O bloco ``resources`` contém a definição dos limites de uso dos recursos de CPU e memória a serem utilizados por cada pod do módulo. Altere conforme a demanda e a disponibilidade de recursos de hardware no cluster.
 
 ## Instalação do Logstash-Federated
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -283,11 +283,11 @@ helm search repo sensedia-helm-s3 -l
 
 Inicialmente, as versões de chart utilizadas neste documento são citadas a seguir. Mas com a evolução do produto ao longo do tempo, novas versões de chart serão disponibilizadas e recomendamos o uso das versões mais novas. Qualquer dúvida, entre em contato com o time de suporte da Sensedia.
 
-* agent-authorization - 1.0.1 ou superior
-* agent-gateway - 1.0.1 ou superior
-* logstash-federated - 1.0.2 ou superior
-* api-authorization - 1.0.0 ou superior
-* api-gateway - 1.0.3 ou superior
+* agent-authorization - 1.13.0 ou superior
+* agent-gateway - 1.14.0 ou superior
+* logstash-federated - 1.5.0 ou superior
+* api-authorization - 2.4.0 ou superior
+* api-gateway - 2.6.0 ou superior
 
 ## Criação de Namespace no Cluster Kubernetes
 
@@ -359,6 +359,13 @@ properties:
     connectionType: "CHANGE_HERE" #Up to you. Are you using CLUSTER or MASTER_SLAVE?
     address: "CHANGE_HERE" #Example: x.x.x.x:6379
     password: "CHANGE_HERE" #Password base64
+    sslEnabled: "false" #Defina "true" se o endpoint do Redis exigir TLS
+    sslVerifyPeer: "false" #Defina "true" para validar o certificado TLS do Redis
+    #--- Os valores abaixo só são usados quando connectionType é "MASTER_SLAVE"
+    masterSlaveReadFrom: "SLAVE"
+    lettuceSentinelHosts: "" #Example: sentinel1:26379,sentinel2:26379
+    lettuceSentinelMasterId: ""
+    lettuceSentinelDefaultPort: ""
   logLevel: INFO
   trackExpires: 7
   #--- IF client in AWS
@@ -392,13 +399,13 @@ Altere os valores definidos como ``CHANGE_HERE`` para os valores condizentes com
 
 Explicação do conteúdo do arquivo ``values.yaml`` do módulo **Agent Authorization**.
 
-* Na **linha 1** é definida a quantidade de réplicas do pod, que executam o módulo e que podem ser executadas no cluster Kubernetes. Altere o valor conforme a demanda e disponibilidade de recursos de CPU, memória e endereços IP.
-* A **linha 4** contém o endereço do Docker Registry e o nome da imagem Docker do respectivo módulo (``gcr.io/production-main-268117/agent-authorization``). Você deve entrar em contato com o time da Sensedia para saber qual a URL do Docker Registry, nome da imagem docker do módulo que deve utilizar e alterar no arquivo ``.yaml`` antes de fazer o deploy.
-* A **linha 5** contém a versão do módulo (``1909.1.1.2``). Você deve entrar em contato com o time da Sensedia para saber qual a versão que deve utilizar e alterar no arquivo ``.yaml`` antes de fazer o deploy.
-* Das **linhas 14 a 17**, encontramos as informações referentes ao redis. Nesta sessão do yaml, é preciso alterar as informações de endereçamento do redis e caso necessário, aplicar uma senha de acesso. Tal senha precisa ser codificada em base64. 
-* As **linhas 23 a 27** contém a definição de autoscaling para o pod. Altere conforme a demanda e a disponibilidade de recursos de hardware no cluster e de endereços IP.
-* As **linhas 29 a 35** contém a definição de ingress e TLS para o módulo. Altere conforme a necessidade do ambiente.
-* As **linhas 37 a 43** contém a definição dos limites de uso dos recursos de CPU e memória a serem utilizados por cada pod do módulo. Altere conforme a demanda e a disponibilidade de recursos de hardware no cluster.
+* Na **linha 4** é definida a quantidade de réplicas do pod, que executam o módulo e que podem ser executadas no cluster Kubernetes. Altere o valor conforme a demanda e disponibilidade de recursos de CPU, memória e endereços IP.
+* A **linha 6** contém o endereço do Docker Registry e o nome da imagem Docker do respectivo módulo (``gcr.io/production-main-268117/agent-authorization``). Você deve entrar em contato com o time da Sensedia para saber qual a URL do Docker Registry, nome da imagem docker do módulo que deve utilizar e alterar no arquivo ``.yaml`` antes de fazer o deploy.
+* A **linha 7** contém a tag/versão da imagem Docker do módulo. Você deve entrar em contato com o time da Sensedia para saber qual a versão que deve utilizar e alterar no arquivo ``.yaml`` antes de fazer o deploy.
+* Das **linhas 14 a 24**, encontramos as informações referentes ao redis. Nesta sessão do yaml, é preciso alterar as informações de endereçamento do redis (``address``) e, caso necessário, aplicar uma senha de acesso (``password``, codificada em base64). Os parâmetros ``sslEnabled`` e ``sslVerifyPeer`` habilitam conexão TLS com o Redis. Os parâmetros ``masterSlaveReadFrom``, ``lettuceSentinelHosts``, ``lettuceSentinelMasterId`` e ``lettuceSentinelDefaultPort`` só se aplicam quando ``connectionType`` é ``MASTER_SLAVE`` e o Redis está configurado com Sentinel.
+* As **linhas 33 a 37** contém a definição de autoscaling para o pod. Altere conforme a demanda e a disponibilidade de recursos de hardware no cluster e de endereços IP.
+* As **linhas 38 a 44** contém a definição de ingress e TLS para o módulo. Altere conforme a necessidade do ambiente.
+* As **linhas 45 a 51** contém a definição dos limites de uso dos recursos de CPU e memória a serem utilizados por cada pod do módulo. Altere conforme a demanda e a disponibilidade de recursos de hardware no cluster.
 
 ## Instalação do Logstash-Federated
 

--- a/kubernetes/README_en.md
+++ b/kubernetes/README_en.md
@@ -285,11 +285,11 @@ helm search repo sensedia-helm-s3 -l
 
 Initially, the chart versions used in this document are mentioned below. However, as the product evolves with time, new chart versions will be made available and we recommend using the latest versions. In case of doubts, get in touch with Sensedia's Support team.
 
-* agent-authorization - 1.0.1 or higher
-* agent-gateway - 1.0.1 or higher
-* logstash-federated - 1.0.2 or higher
-* api-authorization - 1.0.0 or higher
-* api-gateway - 1.0.3 or higher
+* agent-authorization - 1.13.0 or higher
+* agent-gateway - 1.14.0 or higher
+* logstash-federated - 1.5.0 or higher
+* api-authorization - 2.4.0 or higher
+* api-gateway - 2.6.0 or higher
 
 ## Creation of Namespace on the Kubernetes Cluster
 
@@ -361,6 +361,13 @@ properties:
     connectionType: "CHANGE_HERE" #Up to you. Are you using CLUSTER or MASTER_SLAVE?
     address: "CHANGE_HERE" #Example: x.x.x.x:6379
     password: "CHANGE_HERE" #Password base64
+    sslEnabled: "false" #Set to "true" if the Redis endpoint requires TLS
+    sslVerifyPeer: "false" #Set to "true" to validate the Redis TLS certificate
+    #--- Values below are only used when connectionType is "MASTER_SLAVE"
+    masterSlaveReadFrom: "SLAVE"
+    lettuceSentinelHosts: "" #Example: sentinel1:26379,sentinel2:26379
+    lettuceSentinelMasterId: ""
+    lettuceSentinelDefaultPort: ""
   logLevel: INFO
   trackExpires: 7
   #--- IF client in AWS
@@ -394,13 +401,13 @@ Replace the values defined as ``CHANGE_HERE`` with values consistent with your h
 
 Explanation on the content of the ``values.yaml`` file of the **Agent Authorization** module.
 
-* **Line 1** defines the quantity of pod replicas, which execute the module and may be executed on the Kubernetes cluster. Change the value according to the demand and availability of CPU and memory resources and of IP addresses.
-* **Line 4** contains the Docker Registry address and the name of the Docker image of the respective module (``gcr.io/production-main-268117/agent-authorization``). You should get in touch with the Sensedia team to know the Docker Registry URL, module docker image name that you must use and alter in the ``.yaml`` file before deployment.
-* **Line 5** contains the module version (``1909.1.1.2``). You should get in touch with the Sensedia team to know which version to use and alter in the ``.yaml`` file before deployment.
-* **lines 14 to 17**, we find information referring to redis. In this yaml session, you need to change the redis address information and, if necessary, apply a password. Such password must be base64 encoded.
-* **Lines 23 to 27** contain the autoscaling definition for the pod. Alter it according to the demand and availability of hardware resources on the cluster and of IP addresses.
-* **Lines 29 to 35** contain the ingress and TLS definition for the module. Alter it according to the needs of the environment.
-* **Lines 37 to 43** contain the definition of CPU and memory resources usage limit for each pod of the module. Alter it according to the demand and availability of hardware resources on the cluster.
+* **Line 4** defines the quantity of pod replicas, which execute the module and may be executed on the Kubernetes cluster. Change the value according to the demand and availability of CPU and memory resources and of IP addresses.
+* **Line 6** contains the Docker Registry address and the name of the Docker image of the respective module (``gcr.io/production-main-268117/agent-authorization``). You should get in touch with the Sensedia team to know the Docker Registry URL, module docker image name that you must use and alter in the ``.yaml`` file before deployment.
+* **Line 7** contains the tag/version of the module's Docker image. You should get in touch with the Sensedia team to know which version to use and alter in the ``.yaml`` file before deployment.
+* **Lines 14 to 24**, we find information referring to redis. In this yaml session, you need to change the redis address information (``address``) and, if necessary, apply a password (``password``, base64 encoded). The ``sslEnabled`` and ``sslVerifyPeer`` parameters enable a TLS connection to Redis. The ``masterSlaveReadFrom``, ``lettuceSentinelHosts``, ``lettuceSentinelMasterId``, and ``lettuceSentinelDefaultPort`` parameters only apply when ``connectionType`` is ``MASTER_SLAVE`` and Redis is configured with Sentinel.
+* **Lines 33 to 37** contain the autoscaling definition for the pod. Alter it according to the demand and availability of hardware resources on the cluster and of IP addresses.
+* **Lines 38 to 44** contain the ingress and TLS definition for the module. Alter it according to the needs of the environment.
+* **Lines 45 to 51** contain the definition of CPU and memory resources usage limit for each pod of the module. Alter it according to the demand and availability of hardware resources on the cluster.
 
 ## Installing Logstash-Federated
 

--- a/kubernetes/README_en.md
+++ b/kubernetes/README_en.md
@@ -596,4 +596,4 @@ Environment installation is based on gateway pools. These pools represent a grou
 
 ![Add API](../images/add_api_new.jpg)
 
-* Validate your API by making a request to the hybrid gateway; Access this link for documentation on [Validation](../validation/README_pt.md).
+* Validate your API by making a request to the hybrid gateway; Access this link for documentation on [Validation](../validation/README_en.md).

--- a/kubernetes/README_en.md
+++ b/kubernetes/README_en.md
@@ -34,6 +34,7 @@
 
 
 # Hybrid API-Platform - Kubernetes
+> Last reviewed: 2026-08-14
 
 We recommend the hybrid deployment method for clients concerned about latency. This documentation explains how to deploy the modules/services used on the hybrid environment using [Kubernetes](https://kubernetes.io) and [Helm](https://helm.sh).
 
@@ -401,13 +402,12 @@ Replace the values defined as ``CHANGE_HERE`` with values consistent with your h
 
 Explanation on the content of the ``values.yaml`` file of the **Agent Authorization** module.
 
-* **Line 4** defines the quantity of pod replicas, which execute the module and may be executed on the Kubernetes cluster. Change the value according to the demand and availability of CPU and memory resources and of IP addresses.
-* **Line 6** contains the Docker Registry address and the name of the Docker image of the respective module (``gcr.io/production-main-268117/agent-authorization``). You should get in touch with the Sensedia team to know the Docker Registry URL, module docker image name that you must use and alter in the ``.yaml`` file before deployment.
-* **Line 7** contains the tag/version of the module's Docker image. You should get in touch with the Sensedia team to know which version to use and alter in the ``.yaml`` file before deployment.
-* **Lines 14 to 24**, we find information referring to redis. In this yaml session, you need to change the redis address information (``address``) and, if necessary, apply a password (``password``, base64 encoded). The ``sslEnabled`` and ``sslVerifyPeer`` parameters enable a TLS connection to Redis. The ``masterSlaveReadFrom``, ``lettuceSentinelHosts``, ``lettuceSentinelMasterId``, and ``lettuceSentinelDefaultPort`` parameters only apply when ``connectionType`` is ``MASTER_SLAVE`` and Redis is configured with Sentinel.
-* **Lines 33 to 37** contain the autoscaling definition for the pod. Alter it according to the demand and availability of hardware resources on the cluster and of IP addresses.
-* **Lines 38 to 44** contain the ingress and TLS definition for the module. Alter it according to the needs of the environment.
-* **Lines 45 to 51** contain the definition of CPU and memory resources usage limit for each pod of the module. Alter it according to the demand and availability of hardware resources on the cluster.
+* The ``replicaCount`` field defines the quantity of pod replicas, which execute the module and may be executed on the Kubernetes cluster. Change the value according to the demand and availability of CPU and memory resources and of IP addresses.
+* The ``image.repository`` and ``image.tag`` fields contain, respectively, the Docker Registry address and the name of the Docker image of the respective module (``gcr.io/production-main-268117/agent-authorization``), and the image's tag/version. You should get in touch with the Sensedia team to know the Docker Registry URL, module docker image name, and version that you must use, and alter in the ``.yaml`` file before deployment.
+* The ``properties.redis`` block contains the information referring to redis. You need to change the redis address information (``address``) and, if necessary, apply a password (``password``, base64 encoded). The ``sslEnabled`` and ``sslVerifyPeer`` parameters enable a TLS connection to Redis. The ``masterSlaveReadFrom``, ``lettuceSentinelHosts``, ``lettuceSentinelMasterId``, and ``lettuceSentinelDefaultPort`` parameters only apply when ``connectionType`` is ``MASTER_SLAVE`` and Redis is configured with Sentinel.
+* The ``autoscaling`` block contains the autoscaling definition for the pod. Alter it according to the demand and availability of hardware resources on the cluster and of IP addresses.
+* The ``ingress`` block contains the ingress and TLS definition for the module. Alter it according to the needs of the environment.
+* The ``resources`` block contains the definition of CPU and memory resources usage limit for each pod of the module. Alter it according to the demand and availability of hardware resources on the cluster.
 
 ## Installing Logstash-Federated
 

--- a/kubernetes/README_es.md
+++ b/kubernetes/README_es.md
@@ -283,11 +283,11 @@ helm search repo sensedia-helm-s3 -l
 
 Inicialmente, las versiones de charts utilizadas en este documento se citan a continuación. Pero con la evolución del producto a lo largo del tiempo, nuevas versiones de gráficos estarán disponibles y recomendamos utilizar las más recientes. Para cualquier pregunta, póngase en contacto con el equipo de soporte de Sensedia.
 
-* agent-authorization - 1.0.1 o superior
-* agent-gateway - 1.0.1 o superior
-* logstash-federated - 1.0.2 o superior
-* api-authorization - 1.0.0 o superior
-* api-gateway - 1.0.3 o superior
+* agent-authorization - 1.13.0 o superior
+* agent-gateway - 1.14.0 o superior
+* logstash-federated - 1.5.0 o superior
+* api-authorization - 2.4.0 o superior
+* api-gateway - 2.6.0 o superior
 
 ## Creación de Namespace en el Clúster Kubernetes
 
@@ -359,6 +359,13 @@ properties:
     connectionType: "CHANGE_HERE" #Up to you. Are you using CLUSTER or MASTER_SLAVE?
     address: "CHANGE_HERE" #Example: x.x.x.x:6379
     password: "CHANGE_HERE" #Password base64
+    sslEnabled: "false" #Defina "true" si el endpoint de Redis requiere TLS
+    sslVerifyPeer: "false" #Defina "true" para validar el certificado TLS de Redis
+    #--- Los valores a continuación solo se usan cuando connectionType es "MASTER_SLAVE"
+    masterSlaveReadFrom: "SLAVE"
+    lettuceSentinelHosts: "" #Example: sentinel1:26379,sentinel2:26379
+    lettuceSentinelMasterId: ""
+    lettuceSentinelDefaultPort: ""
   logLevel: INFO
   trackExpires: 7
   #--- IF client in AWS
@@ -392,13 +399,13 @@ Cambiar los valores que contienen``CHANGE_HERE`` a valores consistentes con su e
 
 Explicación del contenido del archivo ``values.yaml`` del módulo **Agent Authorization** .
 
-* La **línea 1** define el número de réplicas del pod, que ejecuta el módulo y se puede ejecutar en el clúster de Kubernetes. Cambiar el valor según la demanda y disponibilidad de recursos de CPU, memoria y direcciones IP.
-* La **línea 4** contiene la dirección del Docker Registry y el nombre de la imagen Docker del módulo respectivo (``gcr.io/production-main-268117/agent-authorization`` ). Debe ponerse en contacto con el equipo de Sensedia para averiguar la URL del Docker Registry, el nombre de la imagen docker del módulo que debe usar y cambiar en el ``archivo.yaml`` antes del despliegue.
-* La **línea 5** contiene la versión del módulo (``1909.1.1.2`` ). Debe ponerse en contacto con el equipo de Sensedia para averiguar qué versión usar y cambiar en el archivo ``.yaml`` antes del despliegue.
-* Desde **líneas 14 a 17**, encontramos información referente a redis. En esta sesión de yaml, debe cambiar la información de la dirección de redis y, si es necesario, aplicar una contraseña. Dicha contraseña debe estar codificada en base64.
-* Las **líneas 23 a 27** contienen la definición de autoscaling para el pod. Cambiar según la demanda y disponibilidad de los recursos de hardware en el clúster y las direcciones IP.
-* Las **líneas 29 a 35** contienen la definición de ingress y TLS para el módulo. Cambiar según la necesidad del entorno.
-* Las **líneas 37 a 43** contienen la definición de los límites de uso de los recursos de CPU y memoria que utilizará cada pod del módulo. Cambiar según la demanda y disponibilidad de los recursos de hardware en el clúster.
+* La **línea 4** define el número de réplicas del pod, que ejecuta el módulo y se puede ejecutar en el clúster de Kubernetes. Cambiar el valor según la demanda y disponibilidad de recursos de CPU, memoria y direcciones IP.
+* La **línea 6** contiene la dirección del Docker Registry y el nombre de la imagen Docker del módulo respectivo (``gcr.io/production-main-268117/agent-authorization`` ). Debe ponerse en contacto con el equipo de Sensedia para averiguar la URL del Docker Registry, el nombre de la imagen docker del módulo que debe usar y cambiar en el ``archivo.yaml`` antes del despliegue.
+* La **línea 7** contiene la tag/versión de la imagen Docker del módulo. Debe ponerse en contacto con el equipo de Sensedia para averiguar qué versión usar y cambiar en el archivo ``.yaml`` antes del despliegue.
+* Desde **líneas 14 a 24**, encontramos información referente a redis. En esta sesión de yaml, debe cambiar la información de la dirección de redis (``address``) y, si es necesario, aplicar una contraseña (``password``, codificada en base64). Los parámetros ``sslEnabled`` y ``sslVerifyPeer`` habilitan la conexión TLS con Redis. Los parámetros ``masterSlaveReadFrom``, ``lettuceSentinelHosts``, ``lettuceSentinelMasterId`` y ``lettuceSentinelDefaultPort`` solo se aplican cuando ``connectionType`` es ``MASTER_SLAVE`` y Redis está configurado con Sentinel.
+* Las **líneas 33 a 37** contienen la definición de autoscaling para el pod. Cambiar según la demanda y disponibilidad de los recursos de hardware en el clúster y las direcciones IP.
+* Las **líneas 38 a 44** contienen la definición de ingress y TLS para el módulo. Cambiar según la necesidad del entorno.
+* Las **líneas 45 a 51** contienen la definición de los límites de uso de los recursos de CPU y memoria que utilizará cada pod del módulo. Cambiar según la demanda y disponibilidad de los recursos de hardware en el clúster.
 
 ## Instalación de Logstash-Federated
 

--- a/kubernetes/README_es.md
+++ b/kubernetes/README_es.md
@@ -593,4 +593,4 @@ La instalación del entorno se basa en grupos de puertas de enlace (gateway pool
 
 ![Add API](../images/add_api_new.jpg)
 
-* Para validar su API, realizar una petición a la puerta de enlace híbrida; Accede a este enlace para la documentación de [validación](../validation/README_pt.md).
+* Para validar su API, realizar una petición a la puerta de enlace híbrida; Accede a este enlace para la documentación de [validación](../validation/README_es.md).

--- a/kubernetes/README_es.md
+++ b/kubernetes/README_es.md
@@ -32,6 +32,7 @@
 <!-- TOC -->
 
 # API-Platform Híbrido - Kubernetes
+> Última revisión: 2026-08-14
 
 Se recomienda el modelo de implementación híbrida para los clientes preocupados por la latencia. Esta documentación describe cómo implementar los módulos/servicios utilizados en el entorno híbrido usando [Kubernetes](https://kubernetes.io) y [Helm](https://helm.sh) .
 
@@ -399,13 +400,12 @@ Cambiar los valores que contienen``CHANGE_HERE`` a valores consistentes con su e
 
 Explicación del contenido del archivo ``values.yaml`` del módulo **Agent Authorization** .
 
-* La **línea 4** define el número de réplicas del pod, que ejecuta el módulo y se puede ejecutar en el clúster de Kubernetes. Cambiar el valor según la demanda y disponibilidad de recursos de CPU, memoria y direcciones IP.
-* La **línea 6** contiene la dirección del Docker Registry y el nombre de la imagen Docker del módulo respectivo (``gcr.io/production-main-268117/agent-authorization`` ). Debe ponerse en contacto con el equipo de Sensedia para averiguar la URL del Docker Registry, el nombre de la imagen docker del módulo que debe usar y cambiar en el ``archivo.yaml`` antes del despliegue.
-* La **línea 7** contiene la tag/versión de la imagen Docker del módulo. Debe ponerse en contacto con el equipo de Sensedia para averiguar qué versión usar y cambiar en el archivo ``.yaml`` antes del despliegue.
-* Desde **líneas 14 a 24**, encontramos información referente a redis. En esta sesión de yaml, debe cambiar la información de la dirección de redis (``address``) y, si es necesario, aplicar una contraseña (``password``, codificada en base64). Los parámetros ``sslEnabled`` y ``sslVerifyPeer`` habilitan la conexión TLS con Redis. Los parámetros ``masterSlaveReadFrom``, ``lettuceSentinelHosts``, ``lettuceSentinelMasterId`` y ``lettuceSentinelDefaultPort`` solo se aplican cuando ``connectionType`` es ``MASTER_SLAVE`` y Redis está configurado con Sentinel.
-* Las **líneas 33 a 37** contienen la definición de autoscaling para el pod. Cambiar según la demanda y disponibilidad de los recursos de hardware en el clúster y las direcciones IP.
-* Las **líneas 38 a 44** contienen la definición de ingress y TLS para el módulo. Cambiar según la necesidad del entorno.
-* Las **líneas 45 a 51** contienen la definición de los límites de uso de los recursos de CPU y memoria que utilizará cada pod del módulo. Cambiar según la demanda y disponibilidad de los recursos de hardware en el clúster.
+* El campo ``replicaCount`` define el número de réplicas del pod que ejecuta el módulo y se puede ejecutar en el clúster de Kubernetes. Cambiar el valor según la demanda y disponibilidad de recursos de CPU, memoria y direcciones IP.
+* Los campos ``image.repository`` e ``image.tag`` contienen, respectivamente, la dirección del Docker Registry y el nombre de la imagen Docker del módulo respectivo (``gcr.io/production-main-268117/agent-authorization``), y la tag/versión de la imagen. Debe ponerse en contacto con el equipo de Sensedia para averiguar la URL del Docker Registry, el nombre de la imagen docker del módulo y la versión que debe usar, y cambiar en el archivo ``.yaml`` antes del despliegue.
+* El bloque ``properties.redis`` contiene la información referente a redis. Debe cambiar la información de la dirección de redis (``address``) y, si es necesario, aplicar una contraseña (``password``, codificada en base64). Los parámetros ``sslEnabled`` y ``sslVerifyPeer`` habilitan la conexión TLS con Redis. Los parámetros ``masterSlaveReadFrom``, ``lettuceSentinelHosts``, ``lettuceSentinelMasterId`` y ``lettuceSentinelDefaultPort`` solo se aplican cuando ``connectionType`` es ``MASTER_SLAVE`` y Redis está configurado con Sentinel.
+* El bloque ``autoscaling`` contiene la definición de autoscaling para el pod. Cambiar según la demanda y disponibilidad de los recursos de hardware en el clúster y las direcciones IP.
+* El bloque ``ingress`` contiene la definición de ingress y TLS para el módulo. Cambiar según la necesidad del entorno.
+* El bloque ``resources`` contiene la definición de los límites de uso de los recursos de CPU y memoria que utilizará cada pod del módulo. Cambiar según la demanda y disponibilidad de los recursos de hardware en el clúster.
 
 ## Instalación de Logstash-Federated
 

--- a/kubernetes/helm/values_examples/agent-authorization/values.yaml
+++ b/kubernetes/helm/values_examples/agent-authorization/values.yaml
@@ -19,6 +19,13 @@ properties:
     connectionType: "CHANGE_HERE" #Up to you. Are you using CLUSTER or MASTER_SLAVE?
     address: "CHANGE_HERE" #Example: x.x.x.x:6379
     password: "CHANGE_HERE" #Encode password in base64
+    sslEnabled: "false" #Set to "true" if the Redis endpoint requires TLS
+    sslVerifyPeer: "false" #Set to "true" to validate the Redis TLS certificate
+    #--- Values below are only used when connectionType is "MASTER_SLAVE"
+    masterSlaveReadFrom: "SLAVE"
+    lettuceSentinelHosts: "" #Example: sentinel1:26379,sentinel2:26379
+    lettuceSentinelMasterId: ""
+    lettuceSentinelDefaultPort: ""
   logLevel: INFO
   trackExpires: 7
   #--- IF client in AWS

--- a/kubernetes/helm/values_examples/agent-gateway/values.yaml
+++ b/kubernetes/helm/values_examples/agent-gateway/values.yaml
@@ -16,6 +16,13 @@ properties:
     connectionType: "CHANGE_HERE" #Up to you. Are you using CLUSTER or MASTER_SLAVE?
     compressData: "true"
     password: "CHANGE_HERE" #Encode password in base64
+    sslEnabled: "false" #Set to "true" if the Redis endpoint requires TLS
+    sslVerifyPeer: "false" #Set to "true" to validate the Redis TLS certificate
+    #--- Values below are only used when connectionType is "MASTER_SLAVE"
+    masterSlaveReadFrom: "SLAVE"
+    lettuceSentinelHosts: "" #Example: sentinel1:26379,sentinel2:26379
+    lettuceSentinelMasterId: ""
+    lettuceSentinelDefaultPort: ""
   #--- IF client in AWS
   websocketUri: wss://integration-aws.sensedia.com/websocket
   #--- If client in GCP

--- a/kubernetes/helm/values_examples/api-gateway/values.yaml
+++ b/kubernetes/helm/values_examples/api-gateway/values.yaml
@@ -20,14 +20,29 @@ service:
 properties:
   java_opts: "-Djava.security.egd=file:/dev/./urandom -Dlog4j2.formatMsgNoLookups=True -Dfile.encoding=UTF8 -Xms1536m -Xmx1536m -XX:ParallelGCThreads=1 -XX:ConcGCThreads=1 -Djava.util.concurrent.ForkJoinPool.common.parallelism=1 -XX:CICompilerCount=2 -XX:+UseParallelGC -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:+ExitOnOutOfMemoryError -Dtomcat.relaxedQueryChars='[]|{}^&#x5c;&#x60;&quot;&lt;&gt;' -Dtomcat.maxThreads=400"
   redis_token_connectiontype: "CHANGE_HERE"  #Example MASTER_SLAVE or CLUSTER (#depends on your redis setup)
-  redis_token_address: "redis://CHANGE_HERE" #Example: "redis://x.x.x.x:6379". Note that port is required 
+  redis_token_address: "redis://CHANGE_HERE" #Example: "redis://x.x.x.x:6379". Note that port is required
   redis_token_password: "CHANGE_HERE"
+  #--- Values below are only used when redis_token_connectiontype is "MASTER_SLAVE"
+  redis_token_sentinel_hosts: "" #Example: sentinel1:26379,sentinel2:26379
+  redis_token_sentinel_masterid: ""
+  redis_token_sentinel_default_port: ""
+  redis_token_readfrom_type: "replicaPreferred" #Valid values: master, masterPreferred, upstream, upstreamPreferred, slave, replica, replicaPreferred, nearest, any, anyReplica
   redis_scenario_connectiontype: "CHANGE_HERE"  #Example MASTER_SLAVE or CLUSTER (#depends on your redis setup)
   redis_scenario_address: "redis://CHANGE_HERE" #Example: "redis://x.x.x.x:6379". Note that port is required
   redis_scenario_password: "CHANGE_HERE"
+  #--- Values below are only used when redis_scenario_connectiontype is "MASTER_SLAVE"
+  redis_scenario_sentinel_hosts: "" #Example: sentinel1:26379,sentinel2:26379
+  redis_scenario_sentinel_masterid: ""
+  redis_scenario_sentinel_default_port: ""
+  redis_scenario_readfrom_type: "replicaPreferred" #Valid values: master, masterPreferred, upstream, upstreamPreferred, slave, replica, replicaPreferred, nearest, any, anyReplica
   redis_cache_connectiontype: "CHANGE_HERE"  #Example MASTER_SLAVE or CLUSTER (#depends on your redis setup)
   redis_cache_address: "redis://CHANGE_HERE" #Example: "redis://x.x.x.x:6379". Note that port is required
-  redis_cache_password: "CHANGE_HERE" 
+  redis_cache_password: "CHANGE_HERE"
+  #--- Values below are only used when redis_cache_connectiontype is "MASTER_SLAVE"
+  redis_cache_sentinel_hosts: "" #Example: sentinel1:26379,sentinel2:26379
+  redis_cache_sentinel_masterid: ""
+  redis_cache_sentinel_default_port: ""
+  redis_cache_readfrom_type: "replicaPreferred" #Valid values: master, masterPreferred, upstream, upstreamPreferred, slave, replica, replicaPreferred, nearest, any, anyReplica
   customer_id: "CHANGE_HERE"
   logstash_url: "http://CHANGE_HERE/" #Example "http://x.x.x.x:80/". Note that the last slash is required
   metric_target: "HTTP"

--- a/validation/README_en.md
+++ b/validation/README_en.md
@@ -2,6 +2,7 @@
 <!-- TOC -->
 
 # Validation of the federated flow
+> Last reviewed: 2026-08-14
 
 To perform the flow validation, we use a simple API with a mock interceptor and logs for analysis if necessary.
 For this, it is necessary to have completed all provisioning and configuration of the federated environment.

--- a/validation/README_es.md
+++ b/validation/README_es.md
@@ -2,6 +2,8 @@
 <!-- TOC -->
 
 # Validación del flujo federado
+> Última revisión: 2026-08-14
+
 Para realizar la validación del flujo utilizamos una API simple con un interceptor de mock y logs para, en caso necesario, realizar un análisis.
 Para ello, es necesario haber concluido todo el aprovisionamiento y configuración del Enviroment federado.
 

--- a/validation/README_pt.md
+++ b/validation/README_pt.md
@@ -2,6 +2,7 @@
 <!-- TOC -->
 
 # Validação do fluxo federado
+> Última revisão: 2026-08-14
 
 Para realizar a validação do fluxo utilizamos uma API simples com um interceptor de mock e logs para caso necessário realizarmos uma análise.
 


### PR DESCRIPTION
## Contexto

Parte da task [PLAT-9227](https://sensedia.atlassian.net/browse/PLAT-9227) — auditoria incremental da documentação do híbrido (`api-platform-hybrid`), iniciada durante o trabalho em PLAT-9226 (PR #68). Este PR cresceu de escopo (commits adicionados) para cobrir de uma vez as oportunidades já mapeadas na task, mantendo cada assunto em um commit separado.

## O que muda

1. **Versões mínimas de Helm chart** atualizadas para o que está de fato publicado em `sensedia-helm-s3`.
2. **Exemplo de `values.yaml` do Agent Authorization** com os campos de Redis do chart 1.13.0 (Sentinel/TLS).
3. **`values_examples` de agent-gateway e api-gateway** sincronizados com o mesmo tratamento.
4. **`compose/`**: tags de imagem quebradas, placeholders com erro de digitação, referências a arquivo inexistente, e um exemplo `agent-gateway.yaml` que na verdade mostrava a config do `api-gateway`.
5. **Links internos quebrados** corrigidos (docs de validação por idioma, âncoras desatualizadas).
6. **Data de "última revisão"** adicionada no topo de todos os READMEs do repositório (PT/EN/ES), para dar um sinal rápido de frescor da doc.
7. **Estilo "linha N contém X" substituído por referência a nome de campo** nas duas explicações de exemplo (Agent Authorization em `kubernetes/README*.md` e agent-gateway em `compose/README*.md`) — esse estilo já quebrou duas vezes nesta própria rodada de auditoria conforme o exemplo mudava; referenciar o nome do campo YAML/compose torna a explicação resistente a futuras edições do exemplo. O bloco de exemplo do compose também deixou de usar numeração manual de linha (era renderizado como bloco ``bash``) e passou a ser um bloco ``yaml`` normal, refletindo o arquivo real.

## Como validado

- `helm repo add sensedia-helm-s3 ...` + `helm search repo sensedia-helm-s3 -l` + `sort -V` para a versão mais recente de cada chart.
- `helm pull ... --untar` de cada chart + inspeção do `values.yaml`/README gerado pelo `helm-docs`.
- Links relativos verificados com `find`/`ls` contra os arquivos reais do repositório.
- Tag de imagem com `#` confirmada empiricamente via `docker compose run --rm ... env`.

## Outras oportunidades registradas (fora deste PR, comentários em PLAT-9227)

- Heading levels/títulos não traduzidos em `compose/README_es.md`, `compose/modules/README_es.md`, `compose/all-in-one/README*.md`.
- Versões mínimas de Docker/Docker Compose e tags de imagem do registry privado não verificáveis a partir do repositório.
- Faixa de compatibilidade de Redis/Valkey desatualizada (`< 8.0.0`) — Valkey 8.1.0/8.2.0 já em produção nos tenants; achado reportado em comentário na task, aguardando decisão sobre o texto exato antes de editar (é uma declaração de compatibilidade formal).
- Modernizar a chave `version:` (formato antigo do Compose file) nos exemplos de `compose/` — precisa de teste funcional separado antes de aplicar; candidato a task própria.
